### PR TITLE
Add spend analytics details and deterministic recommendations

### DIFF
--- a/client/src/components/cards/MerchantTable.tsx
+++ b/client/src/components/cards/MerchantTable.tsx
@@ -10,28 +10,28 @@ export function MerchantTable({ merchants, isLoading }: MerchantTableProps) {
   const hasMerchants = merchants.length > 0
 
   return (
-    <Card className="flex h-full flex-col rounded-3xl">
-      <CardHeader className="flex-none">
+    <Card className="flex h-full min-h-[320px] flex-col rounded-3xl p-0">
+      <CardHeader className="flex-none p-6 md:p-8 pb-0">
         <CardTitle className="text-lg font-semibold">Top merchants</CardTitle>
       </CardHeader>
-      <CardContent className="flex-1 overflow-hidden px-0 pb-0">
+      <CardContent className="flex-1 overflow-hidden p-6 md:p-8 pt-4">
         {isLoading ? (
           <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Loading merchants…</div>
         ) : hasMerchants ? (
           <div className="h-full overflow-auto">
-            <table className="w-full min-w-[420px] text-sm">
+            <table className="w-full min-w-[420px] text-sm md:text-base">
               <thead>
-                <tr className="text-left text-xs uppercase text-muted-foreground">
-                  <th className="px-4 pb-3 font-medium">Merchant</th>
-                  <th className="px-4 pb-3 font-medium">Category</th>
-                  <th className="px-4 pb-3 font-medium">Visits</th>
-                  <th className="px-4 pb-3 font-medium">Spend</th>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground md:text-sm">
+                  <th className="pb-3 pr-4 font-medium">Merchant</th>
+                  <th className="pb-3 pr-4 font-medium">Category</th>
+                  <th className="pb-3 pr-4 font-medium">Visits</th>
+                  <th className="pb-3 font-medium">Spend</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/60">
                 {merchants.map((merchant) => (
                   <tr key={merchant.id} className="transition hover:bg-muted/40">
-                    <td className="px-4 py-3">
+                    <td className="py-3 pr-4">
                       <div className="flex items-center gap-3">
                         <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-muted">
                           {merchant.logoUrl ? (
@@ -48,14 +48,14 @@ export function MerchantTable({ merchants, isLoading }: MerchantTableProps) {
                           )}
                         </div>
                         <div>
-                          <p className="font-medium text-foreground">{merchant.name}</p>
+                          <p className="text-sm font-semibold text-foreground md:text-base">{merchant.name}</p>
                           <p className="text-xs text-muted-foreground">Recent activity</p>
                         </div>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-sm text-muted-foreground">{merchant.category}</td>
-                    <td className="px-4 py-3 font-medium">{merchant.count}</td>
-                    <td className="px-4 py-3 font-semibold">
+                    <td className="py-3 pr-4 text-sm text-muted-foreground md:text-base">{merchant.category}</td>
+                    <td className="py-3 pr-4 font-medium">{merchant.count}</td>
+                    <td className="py-3 font-semibold">
                       ${merchant.total.toLocaleString(undefined, { maximumFractionDigits: 2 })}
                     </td>
                   </tr>

--- a/client/src/components/cards/MoneyMomentCard.tsx
+++ b/client/src/components/cards/MoneyMomentCard.tsx
@@ -17,12 +17,12 @@ export type MoneyMomentCardProps = {
 
 export function MoneyMomentCard({ moment }: MoneyMomentCardProps) {
   return (
-    <Card className="hover-lift h-full rounded-3xl bg-white/90 p-4 dark:bg-zinc-900/60">
+    <Card className="hover-lift h-full rounded-3xl bg-white/90 p-5 dark:bg-zinc-900/60 md:p-6">
       <CardContent className="flex h-full flex-col justify-between space-y-4 p-0">
         <div className="flex items-center gap-2 text-primary">{ICON_MAP[moment.type]}</div>
         <div className="space-y-1">
-          <p className="text-sm font-semibold text-foreground">{moment.title}</p>
-          <p className="text-xs text-muted-foreground">{moment.body}</p>
+          <p className="text-sm font-semibold text-foreground md:text-base">{moment.title}</p>
+          <p className="text-xs text-muted-foreground md:text-sm">{moment.body}</p>
         </div>
       </CardContent>
     </Card>

--- a/client/src/components/details/DetailsTable.tsx
+++ b/client/src/components/details/DetailsTable.tsx
@@ -1,0 +1,83 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import type { SpendDetailCategory } from "@/types/api"
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+})
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 1,
+})
+
+export type DetailsTableProps = {
+  data: SpendDetailCategory[]
+  total: number
+  windowDays: number
+  transactionCount: number
+  isLoading?: boolean
+}
+
+export function DetailsTable({ data, total, windowDays, transactionCount, isLoading }: DetailsTableProps) {
+  const hasData = data.length > 0 && total > 0
+
+  return (
+    <Card className="rounded-3xl p-0">
+      <CardHeader className="p-6 md:p-8 pb-0">
+        <CardTitle className="text-lg font-semibold">Category breakdown</CardTitle>
+        <CardDescription>
+          Showing the last {windowDays} days. Totals match your overview donut.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-6 md:p-8 pt-4">
+        {isLoading ? (
+          <div className="flex h-[240px] items-center justify-center text-sm text-muted-foreground">
+            Crunching the numbers…
+          </div>
+        ) : hasData ? (
+          <div className="space-y-4">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[520px] text-sm md:text-base">
+                <thead>
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground md:text-sm">
+                    <th className="pb-3 pr-4">Category</th>
+                    <th className="pb-3 pr-4">Spend</th>
+                    <th className="pb-3 pr-4">Transactions</th>
+                    <th className="pb-3">Share</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/60">
+                  {data.map((row) => (
+                    <tr key={row.key} className="transition hover:bg-muted/40">
+                      <td className="py-3 pr-4 text-sm font-semibold text-foreground md:text-base">{row.key}</td>
+                      <td className="py-3 pr-4 font-semibold">
+                        {currencyFormatter.format(row.amount)}
+                      </td>
+                      <td className="py-3 pr-4 text-sm text-muted-foreground md:text-base">{row.count}</td>
+                      <td className="py-3 font-semibold text-primary">
+                        {percentFormatter.format(Math.min(Math.max(row.pct, 0), 1))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="rounded-2xl bg-muted/40 px-4 py-3 text-sm text-muted-foreground md:text-base">
+              Tracking {transactionCount.toLocaleString()} transactions ·
+              {" "}
+              {currencyFormatter.format(total)} total spend.
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-[240px] flex-col items-center justify-center space-y-2 text-center text-sm text-muted-foreground">
+            <p>No transactions yet in this window.</p>
+            <p>Once spending starts flowing in, you’ll see a detailed category breakdown here.</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/client/src/components/details/MerchantDetailsTable.tsx
+++ b/client/src/components/details/MerchantDetailsTable.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import type { SpendDetailMerchant } from "@/types/api"
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+})
+
+export type MerchantDetailsTableProps = {
+  data: SpendDetailMerchant[]
+  isLoading?: boolean
+}
+
+export function MerchantDetailsTable({ data, isLoading }: MerchantDetailsTableProps) {
+  const hasData = data.length > 0
+
+  return (
+    <Card className="rounded-3xl p-0">
+      <CardHeader className="p-6 md:p-8 pb-0">
+        <CardTitle className="text-lg font-semibold">Merchants</CardTitle>
+        <CardDescription>
+          Categories reflect any custom mappings you’ve added (e.g., KFC → dining).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-6 md:p-8 pt-4">
+        {isLoading ? (
+          <div className="flex h-[240px] items-center justify-center text-sm text-muted-foreground">
+            Loading merchant activity…
+          </div>
+        ) : hasData ? (
+          <div className="space-y-4">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[360px] text-sm md:text-base">
+                <thead>
+                  <tr className="text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground md:text-sm">
+                    <th className="pb-3 pr-4">Merchant</th>
+                    <th className="pb-3 pr-4">Category</th>
+                    <th className="pb-3 pr-4">Transactions</th>
+                    <th className="pb-3">Spend</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/60">
+                  {data.map((row) => (
+                    <tr key={`${row.name}-${row.category}`} className="transition hover:bg-muted/40">
+                      <td className="py-3 pr-4 text-sm font-semibold text-foreground md:text-base">{row.name}</td>
+                      <td className="py-3 pr-4 text-sm text-muted-foreground md:text-base">{row.category}</td>
+                      <td className="py-3 pr-4 font-medium">{row.count}</td>
+                      <td className="py-3 font-semibold">{currencyFormatter.format(row.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-[240px] items-center justify-center text-center text-sm text-muted-foreground">
+            No individual merchants to highlight yet.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+

--- a/client/src/components/recommendations/RecommendationsSection.tsx
+++ b/client/src/components/recommendations/RecommendationsSection.tsx
@@ -1,0 +1,288 @@
+import { useMemo } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { useRecommendations } from "@/hooks/useRecommendations"
+import type { SpendDetailCategory } from "@/types/api"
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+const currencyFormatterWithCents = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+})
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 1,
+})
+
+type RecommendationsSectionProps = {
+  categories: SpendDetailCategory[]
+  total: number
+  windowDays: number
+  isLoadingDetails?: boolean
+  catalogSize?: number
+}
+
+export function RecommendationsSection({
+  categories,
+  total,
+  windowDays,
+  isLoadingDetails,
+  catalogSize,
+}: RecommendationsSectionProps) {
+  const hasSpend = total > 0 && categories.some((category) => category.amount > 0)
+  const monthlySpend = windowDays > 0 ? (total / windowDays) * 30 : total
+
+  const categoryMix = useMemo(() => {
+    if (!hasSpend) return null
+    const mix: Record<string, number> = {}
+    categories.forEach((category) => {
+      if (category.amount > 0) {
+        mix[category.key] = category.amount
+      }
+    })
+    return mix
+  }, [categories, hasSpend])
+
+  const recommendations = useRecommendations({
+    window: 90,
+    categoryMix,
+    monthlySpend,
+    includeExplain: true,
+    enabled: hasSpend,
+  })
+
+  if (isLoadingDetails) {
+    return (
+      <Card className="rounded-3xl p-0">
+        <CardHeader className="p-6 md:p-8 pb-0">
+          <CardTitle className="text-lg font-semibold">Card recommendations</CardTitle>
+          <CardDescription>We’re analysing your recent spending mix…</CardDescription>
+        </CardHeader>
+        <CardContent className="flex h-[260px] items-center justify-center text-sm text-muted-foreground">
+          Calculating deterministic rewards…
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!hasSpend) {
+    return (
+      <Card className="rounded-3xl p-0">
+        <CardHeader className="p-6 md:p-8 pb-0">
+          <CardTitle className="text-lg font-semibold">Card recommendations</CardTitle>
+          <CardDescription>
+            Add some spending data and we’ll score every card in the catalog for you.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 p-6 md:p-8 pt-4 text-sm text-muted-foreground md:text-base">
+          <p>
+            Once we know how you spend, we can show deterministic annual values, fees, and net rewards for each product. For
+            now, browse the {catalogSize ?? 0} cards in the catalog to see what’s available.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (recommendations.isError) {
+    return (
+      <Card className="rounded-3xl p-0">
+        <CardHeader className="p-6 md:p-8 pb-0">
+          <CardTitle className="text-lg font-semibold">Card recommendations</CardTitle>
+        </CardHeader>
+        <CardContent className="p-6 md:p-8 pt-4 text-sm text-muted-foreground">
+          Something went wrong while scoring the catalog. Please try again shortly.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const data = recommendations.data
+  const cards = data?.cards ?? []
+
+  const topCategories = categories.slice(0, 6)
+
+  return (
+    <div className="space-y-6">
+      <Card className="rounded-3xl p-0">
+        <CardHeader className="p-6 md:p-8 pb-0">
+          <CardTitle className="text-lg font-semibold">Based on your recent mix</CardTitle>
+          <CardDescription>
+            About {currencyFormatter.format(Math.round(monthlySpend))} in monthly spend across your top categories.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-6 md:p-8 pt-4">
+          <div className="grid gap-3">
+            {topCategories.map((category) => (
+              <div key={category.key} className="flex items-center justify-between rounded-2xl bg-muted/40 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground md:text-base">{category.key}</p>
+                  <p className="text-xs text-muted-foreground">
+                    ≈ {currencyFormatterWithCents.format(category.pct * monthlySpend)} / month
+                  </p>
+                </div>
+                <span className="text-sm font-semibold text-primary md:text-base">
+                  {percentFormatter.format(Math.min(Math.max(category.pct, 0), 1))}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {recommendations.isLoading ? (
+        <Card className="rounded-3xl p-0">
+          <CardHeader className="p-6 md:p-8 pb-0">
+            <CardTitle className="text-lg font-semibold">Scoring cards…</CardTitle>
+            <CardDescription>Evaluating base rates, bonus categories, and fees.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            Working through the catalog…
+          </CardContent>
+        </Card>
+      ) : cards.length === 0 ? (
+        <Card className="rounded-3xl p-0">
+          <CardHeader className="p-6 md:p-8 pb-0">
+            <CardTitle className="text-lg font-semibold">No clear winner yet</CardTitle>
+          </CardHeader>
+          <CardContent className="p-6 md:p-8 pt-4 text-sm text-muted-foreground md:text-base">
+            We couldn’t find a strong match with your current mix. Try linking more cards or broadening your spending history.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {data?.explanation ? (
+            <Card className="rounded-3xl border border-primary/20 bg-primary/5 p-0">
+              <CardHeader className="p-6 md:p-8 pb-0">
+                <CardTitle className="text-base font-semibold text-primary">Why these picks</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 p-6 md:p-8 pt-4 text-sm text-primary md:text-base">
+                {data.explanation
+                  .split(/\n+/)
+                  .map((line) => line.trim())
+                  .filter(Boolean)
+                  .map((line, index) => (
+                    <p key={index} className="leading-relaxed">
+                      {line.replace(/^[-•\s]+/, "")}
+                    </p>
+                  ))}
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {cards.map((card, index) => (
+            <Card key={card.slug ?? card.id ?? index} className="rounded-3xl p-0">
+              <CardHeader className="p-6 md:p-8 pb-4">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <CardTitle className="text-xl font-semibold text-foreground">
+                      #{index + 1} · {card.product_name ?? card.slug ?? "Card"}
+                    </CardTitle>
+                    <CardDescription>
+                      {[card.issuer, card.network].filter(Boolean).join(" • ") || "Card issuer"}
+                    </CardDescription>
+                  </div>
+                  {card.link_url ? (
+                    <Button asChild size="sm" className="self-start">
+                      <a href={card.link_url} target="_blank" rel="noreferrer">
+                        Apply now
+                      </a>
+                    </Button>
+                  ) : null}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-6 p-6 md:p-8 pt-0">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <StatBlock label="Est. annual rewards" value={currencyFormatterWithCents.format(card.annual_reward)} />
+                  <StatBlock label="Annual fee" value={currencyFormatterWithCents.format(card.annual_fee)} />
+                  <StatBlock label="Net yearly value" value={currencyFormatterWithCents.format(card.net)} highlight />
+                </div>
+
+                {card.highlights.length > 0 ? (
+                  <div className="space-y-2">
+                    <h3 className="text-sm font-semibold text-foreground md:text-base">Why it fits</h3>
+                    <ul className="space-y-1 text-sm text-muted-foreground md:text-base">
+                      {card.highlights.map((highlight, highlightIndex) => (
+                        <li key={highlightIndex} className="flex gap-2">
+                          <span className="text-primary">•</span>
+                          <span>{highlight}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-1">
+                    <h4 className="text-sm font-semibold text-foreground md:text-base">Base everywhere</h4>
+                    <p className="text-sm text-muted-foreground md:text-base">
+                      {percentFormatter.format(card.base_cashback)} back on all spend — worth
+                      {" "}
+                      {currencyFormatterWithCents.format(card.breakdown.base.monthly_amount)} each month.
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <h4 className="text-sm font-semibold text-foreground md:text-base">Bonus categories</h4>
+                    <ul className="space-y-1 text-sm text-muted-foreground md:text-base">
+                      {card.breakdown.bonuses.length === 0 ? (
+                        <li>No additional category boosts.</li>
+                      ) : (
+                        card.breakdown.bonuses.map((bonus) => (
+                          <li key={bonus.category}>
+                            {percentFormatter.format(bonus.rate)} on {bonus.category}
+                            {bonus.cap_monthly ? ` (up to ${currencyFormatterWithCents.format(bonus.cap_monthly)} / mo)` : ""}
+                          </li>
+                        ))
+                      )}
+                    </ul>
+                  </div>
+                </div>
+
+                {card.breakdown.welcome && card.breakdown.welcome.value > 0 ? (
+                  <div className="rounded-2xl bg-muted/40 px-4 py-3 text-sm text-muted-foreground md:text-base">
+                    Intro bonus worth approximately {currencyFormatterWithCents.format(card.breakdown.welcome.value)}
+                    {card.breakdown.welcome.min_spend
+                      ? ` after ${currencyFormatterWithCents.format(card.breakdown.welcome.min_spend)} in spend`
+                      : ""}
+                    {card.breakdown.welcome.window_days
+                      ? ` within ${card.breakdown.welcome.window_days} days`
+                      : ""}
+                    .
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type StatBlockProps = {
+  label: string
+  value: string
+  highlight?: boolean
+}
+
+function StatBlock({ label, value, highlight }: StatBlockProps) {
+  return (
+    <div
+      className={`rounded-2xl border px-4 py-3 text-sm md:text-base ${
+        highlight ? "border-primary/40 bg-primary/5 text-primary" : "border-border/60 text-foreground"
+      }`}
+    >
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold md:text-xl">{value}</p>
+    </div>
+  )
+}
+

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -1,7 +1,15 @@
 import { useMutation, useQuery, useQueryClient, type UseMutationOptions, type UseQueryOptions } from "@tanstack/react-query"
 
 import { apiFetch } from "@/lib/api-client"
-import type { CardRow, Me, MerchantRow, MoneyMoment, Preferences, SpendSummary } from "@/types/api"
+import type {
+  CardRow,
+  Me,
+  MerchantRow,
+  MoneyMoment,
+  Preferences,
+  SpendDetails,
+  SpendSummary,
+} from "@/types/api"
 
 const DEFAULT_STALE_TIME = 60_000
 
@@ -19,7 +27,7 @@ export function useMe(options?: QueryOpts<Me>) {
 }
 
 export function useSpendSummary(
-  windowDays: number, 
+  windowDays: number,
   options?: QueryOpts<SpendSummary> & { cardIds?: string[] }
 ) {
   const { cardIds, ...queryOptions } = options || {}
@@ -32,6 +40,24 @@ export function useSpendSummary(
   return useQuery({
     queryKey: ["spend-summary", { windowDays, cardIds }],
     queryFn: () => apiFetch<SpendSummary>(`/spend/summary?${query.toString()}`),
+    ...queryOptions,
+  })
+}
+
+export function useSpendDetails(
+  windowDays: number,
+  options?: QueryOpts<SpendDetails> & { cardIds?: string[] }
+) {
+  const { cardIds, ...queryOptions } = options || {}
+  const query = new URLSearchParams({ window: String(windowDays) })
+
+  if (cardIds && cardIds.length > 0) {
+    cardIds.forEach((id) => query.append("cardIds", id))
+  }
+
+  return useQuery({
+    queryKey: ["spend-details", { windowDays, cardIds }],
+    queryFn: () => apiFetch<SpendDetails>(`/spend/details?${query.toString()}`),
     ...queryOptions,
   })
 }

--- a/client/src/hooks/useCards.ts
+++ b/client/src/hooks/useCards.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient, type UseMutationOptions, type UseQueryOptions } from "@tanstack/react-query"
 
 import { apiFetch } from "@/lib/api-client"
-import type { CardDetails, CardRow } from "@/types/api"
+import type { CardDetails, CardRow, CreditCardProduct } from "@/types/api"
 
 type QueryOpts<TData> = Omit<UseQueryOptions<TData, Error, TData, unknown[]>, "queryKey" | "queryFn">
 type MutationOpts<TData, TVariables> = Omit<UseMutationOptions<TData, Error, TVariables, unknown>, "mutationFn">
@@ -10,6 +10,24 @@ export function useCards(options?: QueryOpts<CardRow[]>) {
   return useQuery({
     queryKey: ["cards"],
     queryFn: () => apiFetch<CardRow[]>("/cards"),
+    ...options,
+  })
+}
+
+export function useCardCatalog(
+  params?: { active?: boolean },
+  options?: QueryOpts<CreditCardProduct[]>
+) {
+  const active = params?.active
+  const path =
+    active === undefined
+      ? "/cards/catalog"
+      : `/cards/catalog?active=${active ? "1" : "0"}`
+
+  return useQuery({
+    queryKey: ["card-catalog", { active: active ?? null }],
+    queryFn: () => apiFetch<CreditCardProduct[]>(path),
+    staleTime: 60_000,
     ...options,
   })
 }

--- a/client/src/hooks/useRecommendations.ts
+++ b/client/src/hooks/useRecommendations.ts
@@ -1,0 +1,75 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+
+import { apiFetch } from "@/lib/api-client"
+import type { RecommendationResponse } from "@/types/api"
+
+type QueryOpts = Omit<UseQueryOptions<RecommendationResponse, Error, RecommendationResponse, unknown[]>, "queryKey" | "queryFn">
+
+export type UseRecommendationsParams = {
+  window?: number
+  categoryMix?: Record<string, number> | null
+  monthlySpend?: number
+  includeExplain?: boolean
+  enabled?: boolean
+  options?: QueryOpts
+}
+
+function normaliseMix(mix: Record<string, number> | null | undefined) {
+  if (!mix) return null
+  const entries = Object.entries(mix)
+    .map(([key, value]) => {
+      const numeric = Number(value)
+      return Number.isFinite(numeric) && numeric > 0 ? [key, numeric] : null
+    })
+    .filter((entry): entry is [string, number] => Boolean(entry))
+
+  const total = entries.reduce((sum, [, value]) => sum + value, 0)
+  if (total <= 0) return null
+
+  return Object.fromEntries(entries.map(([key, value]) => [key, value / total]))
+}
+
+export function useRecommendations(params: UseRecommendationsParams = {}) {
+  const {
+    window = 90,
+    categoryMix,
+    monthlySpend,
+    includeExplain = true,
+    enabled = true,
+    options,
+  } = params
+
+  const normalisedMix = normaliseMix(categoryMix)
+  const mixKey = normalisedMix
+    ? Object.entries(normalisedMix)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => `${key}:${value.toFixed(6)}`)
+        .join("|")
+    : "auto"
+
+  const payload: Record<string, unknown> = {
+    window,
+    include_explain: includeExplain,
+  }
+
+  if (normalisedMix) {
+    payload.category_mix = normalisedMix
+  }
+
+  if (typeof monthlySpend === "number" && Number.isFinite(monthlySpend)) {
+    payload.monthly_spend = monthlySpend
+  }
+
+  return useQuery({
+    queryKey: ["recommendations", { window, mixKey, monthlySpend: monthlySpend ?? null, includeExplain }],
+    enabled: enabled && (!normalisedMix ? true : Object.keys(normalisedMix).length > 0),
+    queryFn: () =>
+      apiFetch<RecommendationResponse>("/recommendations", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    staleTime: 60_000,
+    ...options,
+  })
+}
+

--- a/client/src/pages/CardsPage.tsx
+++ b/client/src/pages/CardsPage.tsx
@@ -1,13 +1,45 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { AddCardDialog } from "@/components/cards/AddCardDialog"
-import { useCards } from "@/hooks/useCards"
+import { useCardCatalog, useCards } from "@/hooks/useCards"
+import type { CreditCardProduct } from "@/types/api"
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 1,
+})
+
+type CardsTab = "linked" | "catalog"
+
+const TABS: { id: CardsTab; label: string }[] = [
+  { id: "linked", label: "Linked cards" },
+  { id: "catalog", label: "All cards" },
+]
+
+const ANNUAL_FEE_FILTERS = [
+  { value: "all", label: "Any annual fee" },
+  { value: "0", label: "No annual fee" },
+  { value: "low", label: "Up to $99" },
+  { value: "mid", label: "$100 – $199" },
+  { value: "high", label: "$200+" },
+]
 
 export default function CardsPage() {
   const [dialogOpen, setDialogOpen] = useState(false)
   const cardsQuery = useCards()
+  const catalogQuery = useCardCatalog({ active: true })
+  const [activeTab, setActiveTab] = useState<CardsTab>("linked")
+
   const totalCards = cardsQuery.data?.length ?? 0
   const cardsLoading = cardsQuery.isLoading
 
@@ -17,28 +49,249 @@ export default function CardsPage() {
       ? "No cards linked yet."
       : `${totalCards} card${totalCards === 1 ? "" : "s"} linked.`
 
-  return (
-    <div className="mx-auto max-w-3xl space-y-6">
-      <Card className="rounded-3xl">
-        <CardHeader>
-          <CardTitle className="text-xl font-semibold">Add a credit card</CardTitle>
-          <CardDescription>
-            Connect your go-to cards so we can tailor insights and recommendations. Detailed card management is coming soon.
-          </CardDescription>
+  const catalogCards = catalogQuery.data ?? []
+
+  const issuers = useMemo(() => {
+    const values = new Set<string>()
+    catalogCards.forEach((card) => {
+      if (card.issuer) {
+        values.add(card.issuer)
+      }
+    })
+    return Array.from(values).sort((a, b) => a.localeCompare(b))
+  }, [catalogCards])
+
+  const categories = useMemo(() => {
+    const values = new Set<string>()
+    catalogCards.forEach((card) => {
+      card.rewards.forEach((reward) => {
+        if (reward.category) {
+          values.add(reward.category)
+        }
+      })
+    })
+    return Array.from(values).sort((a, b) => a.localeCompare(b))
+  }, [catalogCards])
+
+  const [issuerFilter, setIssuerFilter] = useState<string>("all")
+  const [categoryFilter, setCategoryFilter] = useState<string>("all")
+  const [annualFeeFilter, setAnnualFeeFilter] = useState<string>("all")
+
+  const filteredCatalog = useMemo(() => {
+    return catalogCards.filter((card) => {
+      const matchesIssuer = issuerFilter === "all" || card.issuer === issuerFilter
+      const matchesCategory =
+        categoryFilter === "all" || card.rewards.some((reward) => reward.category === categoryFilter)
+      const matchesFee = matchesAnnualFee(card.annual_fee, annualFeeFilter)
+      return matchesIssuer && matchesCategory && matchesFee
+    })
+  }, [catalogCards, issuerFilter, categoryFilter, annualFeeFilter])
+
+  const linkedContent = (
+    <Card className="rounded-3xl p-0">
+      <CardHeader className="p-6 md:p-8 pb-0">
+        <CardTitle className="text-xl font-semibold">Add a credit card</CardTitle>
+        <CardDescription>
+          Connect your go-to cards so we can tailor insights and recommendations. Detailed card management is coming soon.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-6 md:p-8 pt-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-muted-foreground">{linkedText}</div>
+          <Button onClick={() => setDialogOpen(true)} size="lg">
+            Add card
+          </Button>
+        </div>
+        <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 p-4 text-sm text-muted-foreground">
+          We’ll surface your cards here next, along with syncing controls and product matches.
+        </div>
+      </CardContent>
+    </Card>
+  )
+
+  const catalogContent = (
+    <div className="space-y-6">
+      <Card className="rounded-3xl p-0">
+        <CardHeader className="p-6 md:p-8 pb-0">
+          <CardTitle className="text-xl font-semibold">All cards</CardTitle>
+          <CardDescription>Deterministic catalog data — no PII, no surprises.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-sm text-muted-foreground">{linkedText}</div>
-            <Button onClick={() => setDialogOpen(true)} size="lg">
-              Add card
-            </Button>
-          </div>
-          <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 p-4 text-sm text-muted-foreground">
-            We'll surface your cards here next, along with syncing controls and product matches.
+        <CardContent className="space-y-4 p-6 md:p-8 pt-4">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Select value={issuerFilter} onValueChange={setIssuerFilter}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filter by issuer" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All issuers</SelectItem>
+                {issuers.map((issuer) => (
+                  <SelectItem key={issuer} value={issuer}>
+                    {issuer}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={annualFeeFilter} onValueChange={setAnnualFeeFilter}>
+              <SelectTrigger>
+                <SelectValue placeholder="Annual fee" />
+              </SelectTrigger>
+              <SelectContent>
+                {ANNUAL_FEE_FILTERS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+              <SelectTrigger>
+                <SelectValue placeholder="Bonus category" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All categories</SelectItem>
+                {categories.map((category) => (
+                  <SelectItem key={category} value={category}>
+                    {category}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </CardContent>
       </Card>
+
+      {catalogQuery.isLoading ? (
+        <Card className="rounded-3xl p-0">
+          <CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            Loading catalog…
+          </CardContent>
+        </Card>
+      ) : filteredCatalog.length === 0 ? (
+        <Card className="rounded-3xl p-0">
+          <CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            No cards match the selected filters.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2">
+          {filteredCatalog.map((card) => (
+            <CatalogCard key={card.slug} card={card} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-8 px-4 md:px-6 lg:px-8">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex gap-2 rounded-full border border-border/60 bg-white/80 p-1 text-sm shadow-sm backdrop-blur dark:bg-zinc-900/60">
+          {TABS.map((tab) => {
+            const isActive = tab.id === activeTab
+            const baseClasses = "rounded-full px-4 py-1.5 text-sm font-medium transition focus:outline-none"
+            const activeClasses = "bg-primary text-primary-foreground shadow-soft"
+            const inactiveClasses = "text-muted-foreground hover:text-foreground"
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                className={`${baseClasses} ${isActive ? activeClasses : inactiveClasses}`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {activeTab === "linked" ? linkedContent : catalogContent}
+
       <AddCardDialog open={dialogOpen} onOpenChange={setDialogOpen} />
     </div>
   )
 }
+
+function matchesAnnualFee(fee: number, filter: string) {
+  if (filter === "all") return true
+  if (filter === "0") return fee === 0
+  if (filter === "low") return fee > 0 && fee < 100
+  if (filter === "mid") return fee >= 100 && fee < 200
+  if (filter === "high") return fee >= 200
+  return true
+}
+
+type CatalogCardProps = {
+  card: CreditCardProduct
+}
+
+function CatalogCard({ card }: CatalogCardProps) {
+  const topRewards = card.rewards.slice(0, 3)
+  const welcome = card.welcome_offer
+
+  return (
+    <Card className="rounded-3xl p-0">
+      <CardHeader className="space-y-1 p-6 md:p-8 pb-4">
+        <CardTitle className="text-xl font-semibold text-foreground">{card.product_name}</CardTitle>
+        <CardDescription>{[card.issuer, card.network].filter(Boolean).join(" • ")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 p-6 md:p-8 pt-0 text-sm md:text-base">
+        <div className="grid gap-2 sm:grid-cols-3">
+          <DetailBlock label="Annual fee" value={currencyFormatter.format(card.annual_fee)} />
+          <DetailBlock label="Base rate" value={percentFormatter.format(card.base_cashback)} />
+          <DetailBlock
+            label="Foreign Tx fee"
+            value={card.foreign_tx_fee ? currencyFormatter.format(card.foreign_tx_fee) : "$0"}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold text-foreground md:text-base">Bonus categories</h4>
+          {topRewards.length === 0 ? (
+            <p className="text-sm text-muted-foreground md:text-base">No published category boosts.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {topRewards.map((reward) => (
+                <Badge key={reward.category} variant="secondary" className="rounded-full px-3 py-1 text-xs md:text-sm">
+                  {reward.category}: {percentFormatter.format(reward.rate)}
+                  {reward.cap_monthly ? ` up to ${currencyFormatter.format(reward.cap_monthly)} / mo` : ""}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {welcome && (welcome.bonus_value_usd || welcome.min_spend) ? (
+          <div className="rounded-2xl bg-muted/40 px-4 py-3 text-sm text-muted-foreground md:text-base">
+            Welcome offer worth approximately {currencyFormatter.format(welcome.bonus_value_usd ?? 0)}
+            {welcome.min_spend ? ` after ${currencyFormatter.format(welcome.min_spend)} in spend` : ""}
+            {welcome.window_days ? ` within ${welcome.window_days} days` : ""}.
+          </div>
+        ) : null}
+
+        {card.link_url ? (
+          <Button asChild variant="outline" size="sm">
+            <a href={card.link_url} target="_blank" rel="noreferrer">
+              View card details
+            </a>
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+type DetailBlockProps = {
+  label: string
+  value: string
+}
+
+function DetailBlock({ label, value }: DetailBlockProps) {
+  return (
+    <div className="rounded-2xl border border-border/60 px-4 py-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-sm font-semibold text-foreground md:text-base">{value}</p>
+    </div>
+  )
+}
+

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 
 import { Button } from "@/components/ui/button"
@@ -9,7 +9,18 @@ import { DonutChart } from "@/components/charts/DonutChart"
 import { MerchantTable } from "@/components/cards/MerchantTable"
 import { MoneyMomentCard } from "@/components/cards/MoneyMomentCard"
 import { PageSection } from "@/components/layout/PageSection"
-import { useAccounts, useMe, useMerchants, useMoneyMoments, useSpendSummary } from "@/hooks/useApi"
+import { DetailsTable } from "@/components/details/DetailsTable"
+import { MerchantDetailsTable } from "@/components/details/MerchantDetailsTable"
+import { RecommendationsSection } from "@/components/recommendations/RecommendationsSection"
+import {
+  useAccounts,
+  useMe,
+  useMerchants,
+  useMoneyMoments,
+  useSpendDetails,
+  useSpendSummary,
+} from "@/hooks/useApi"
+import { useCardCatalog } from "@/hooks/useCards"
 import type { CardRow } from "@/types/api"
 
 const currencyFormatter = new Intl.NumberFormat(undefined, {
@@ -35,6 +46,8 @@ function formatLastSynced(card: CardRow) {
   return `Synced ${date.toLocaleDateString()}`
 }
 
+const DETAILS_WINDOW_DAYS = 30
+
 export function HomePage() {
   const { data: me } = useMe()
   const accounts = useAccounts()
@@ -43,24 +56,28 @@ export function HomePage() {
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([])
   const cardIdsForFiltering = selectedCardIds.length > 0 ? selectedCardIds : undefined
 
-  const summary = useSpendSummary(30, { cardIds: cardIdsForFiltering })
-  const merchants = useMerchants({ limit: 8, windowDays: 30, cardIds: cardIdsForFiltering })
-  const moments = useMoneyMoments(30, { cardIds: cardIdsForFiltering })
+  const summary = useSpendSummary(DETAILS_WINDOW_DAYS, { cardIds: cardIdsForFiltering })
+  const spendDetails = useSpendDetails(DETAILS_WINDOW_DAYS, { cardIds: cardIdsForFiltering })
+  const merchants = useMerchants({ limit: 8, windowDays: DETAILS_WINDOW_DAYS, cardIds: cardIdsForFiltering })
+  const moments = useMoneyMoments(DETAILS_WINDOW_DAYS, { cardIds: cardIdsForFiltering })
+  const catalog = useCardCatalog({ active: true })
 
   const stats = summary.data?.stats ?? { totalSpend: 0, txns: 0, accounts: 0 }
   const categories = summary.data?.byCategory ?? []
   const topCategories = categories.slice(0, 6)
-  const otherCategoryCount = categories.length > topCategories.length ? categories.length - topCategories.length : 0
   const merchantRows = merchants.data ?? []
   const momentsList = moments.data ?? []
-  const topCategory = topCategories[0]
+
+  const detailData = spendDetails.data
+  const detailCategories = detailData?.categories ?? []
+  const detailMerchants = detailData?.merchants ?? []
+  const detailTotal = detailData?.total ?? 0
+  const detailTransactions = detailData?.transactionCount ?? 0
 
   const greeting = me?.name?.trim() || (me?.email ? me.email.split("@")[0] : "there")
 
   const handleCardToggle = (cardId: string) => {
-    setSelectedCardIds((prev) =>
-      prev.includes(cardId) ? prev.filter((id) => id !== cardId) : [...prev, cardId]
-    )
+    setSelectedCardIds((prev) => (prev.includes(cardId) ? prev.filter((id) => id !== cardId) : [...prev, cardId]))
   }
 
   const handleSelectAllCards = () => {
@@ -71,208 +88,197 @@ export function HomePage() {
     setSelectedCardIds([])
   }
 
-  const selectedCardsText =
-    selectedCardIds.length === 0
-      ? "All cards"
-      : selectedCardIds.length === accountRows.length
-        ? "All cards"
-        : `${selectedCardIds.length} selected card${selectedCardIds.length > 1 ? "s" : ""}`
+  const selectedCardsText = useMemo(() => {
+    if (selectedCardIds.length === 0 || selectedCardIds.length === accountRows.length) {
+      return "All cards"
+    }
+    return `${selectedCardIds.length} selected card${selectedCardIds.length > 1 ? "s" : ""}`
+  }, [accountRows.length, selectedCardIds])
 
   const [activeTab, setActiveTab] = useState<HomeTab>("overview")
 
   const overviewContent = (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-12">
-      <div className="md:col-span-12">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <StatTile label="Total spend" value={currencyFormatter.format(stats.totalSpend)} />
-          <StatTile label="Transactions" value={stats.txns.toLocaleString()} />
-          <StatTile label="Active cards" value={stats.accounts.toString()} />
-        </div>
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatTile label="Total spend" value={currencyFormatter.format(stats.totalSpend)} />
+        <StatTile label="Transactions" value={stats.txns.toLocaleString()} />
+        <StatTile label="Active cards" value={stats.accounts.toString()} />
       </div>
 
-      <Card className="md:col-span-5 rounded-3xl">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold">Spending mix</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex flex-col gap-4 md:flex-row">
-            <div className="h-64 flex-1">
-              <DonutChart
-                data={topCategories}
-                isLoading={summary.isLoading}
-                emptyMessage="No spending yet in the last 30 days."
-              />
-            </div>
-            <div className="flex-1 space-y-2 text-sm">
-              {summary.isLoading ? (
-                <div className="flex h-full items-center justify-center rounded-2xl bg-muted/40 px-4 text-muted-foreground">
-                  Loading categories…
+      <div className="grid grid-cols-12 gap-6 md:gap-8">
+        <section className="col-span-12 lg:col-span-8 space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card className="min-h-[320px] rounded-3xl p-0">
+              <CardHeader className="p-6 md:p-8 pb-0">
+                <CardTitle className="text-lg font-semibold">Spending mix</CardTitle>
+                <CardDescription>Top categories from the last {DETAILS_WINDOW_DAYS} days.</CardDescription>
+              </CardHeader>
+              <CardContent className="flex h-full flex-col justify-between gap-4 p-6 md:p-8 pt-4">
+                <div className="flex flex-col gap-4 md:flex-row">
+                  <div className="h-64 flex-1">
+                    <DonutChart
+                      data={topCategories}
+                      isLoading={summary.isLoading}
+                      emptyMessage="No spending yet in this window."
+                    />
+                  </div>
+                  <div className="flex-1 space-y-2 text-sm md:text-base">
+                    {summary.isLoading ? (
+                      <div className="flex h-full items-center justify-center rounded-2xl bg-muted/40 px-4 text-muted-foreground">
+                        Loading categories…
+                      </div>
+                    ) : topCategories.length ? (
+                      <div className="space-y-2">
+                        {topCategories.map((category) => (
+                          <div
+                            key={category.name}
+                            className="flex items-center justify-between rounded-2xl bg-muted/40 px-4 py-2"
+                          >
+                            <span className="font-medium text-foreground">{category.name}</span>
+                            <span className="font-semibold">{currencyFormatter.format(category.total)}</span>
+                          </div>
+                        ))}
+                        {categories.length > topCategories.length ? (
+                          <p className="text-xs text-muted-foreground">
+                            +{categories.length - topCategories.length} more categories tracked.
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <div className="flex h-full items-center justify-center rounded-2xl bg-muted/40 px-4 text-muted-foreground">
+                        No spending yet in this window.
+                      </div>
+                    )}
+                  </div>
                 </div>
-              ) : topCategories.length ? (
-                <div className="space-y-2">
-                  {topCategories.map((category) => (
-                    <div
-                      key={category.name}
-                      className="flex items-center justify-between rounded-2xl bg-muted/40 px-4 py-2"
-                    >
-                      <span className="font-medium text-foreground">{category.name}</span>
-                      <span className="font-semibold">
-                        {currencyFormatter.format(category.total)}
-                      </span>
-                    </div>
+              </CardContent>
+            </Card>
+
+            <MerchantTable merchants={merchantRows} isLoading={merchants.isLoading} />
+          </div>
+
+          <Card className="rounded-3xl p-0">
+            <CardHeader className="p-6 md:p-8 pb-0">
+              <CardTitle className="text-lg font-semibold">Money moments</CardTitle>
+            </CardHeader>
+            <CardContent className="p-6 md:p-8 pt-4">
+              {moments.isLoading ? (
+                <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+                  Loading insights…
+                </div>
+              ) : momentsList.length ? (
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {momentsList.map((moment) => (
+                    <MoneyMomentCard key={moment.id} moment={moment} />
                   ))}
-                  {otherCategoryCount > 0 ? (
-                    <p className="text-xs text-muted-foreground">
-                      +{otherCategoryCount} more categor{otherCategoryCount === 1 ? "y" : "ies"} tracked.
-                    </p>
-                  ) : null}
                 </div>
               ) : (
-                <div className="flex h-full items-center justify-center rounded-2xl bg-muted/40 px-4 text-muted-foreground">
-                  No spending yet in the last 30 days.
+                <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+                  We’ll highlight tips and wins here.
                 </div>
               )}
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Showing top categories for the last 30 days. See <span className="font-medium text-foreground">Details</span> for full
-            breakdown.
-          </p>
-        </CardContent>
-      </Card>
+            </CardContent>
+          </Card>
+        </section>
 
-      <div className="md:col-span-4">
-        <MerchantTable merchants={merchantRows} isLoading={merchants.isLoading} />
-      </div>
-
-      <Card className="md:col-span-3 min-h-[16rem] rounded-3xl">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold">Linked cards</CardTitle>
-          {accountRows.length > 1 && (
-            <div className="text-xs text-muted-foreground">
-              <p className="mb-2">Select cards to filter data: {selectedCardsText}</p>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleSelectAllCards}
-                  disabled={selectedCardIds.length === accountRows.length}
-                >
-                  Select All
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleClearSelection}
-                  disabled={selectedCardIds.length === 0}
-                >
-                  Clear
-                </Button>
-              </div>
-            </div>
-          )}
-        </CardHeader>
-        <CardContent className="flex h-64 flex-col gap-3 overflow-auto px-0 pb-0">
-          {accounts.isLoading ? (
-            <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">Loading cards…</div>
-          ) : accountRows.length ? (
-            accountRows.map((card) => (
-              <div key={card.id} className="flex items-center gap-3 px-4 py-3">
-                {accountRows.length > 1 && (
-                  <Checkbox
-                    checked={selectedCardIds.includes(card.id)}
-                    onCheckedChange={() => handleCardToggle(card.id)}
-                  />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold text-foreground">{card.nickname}</p>
-                  <p className="text-xs text-muted-foreground">{card.issuer} •••• {card.mask}</p>
-                  <p className="text-xs text-muted-foreground">{formatLastSynced(card)}</p>
+        <aside className="col-span-12 lg:col-span-4 space-y-6">
+          <Card className="rounded-3xl p-0">
+            <CardHeader className="p-6 md:p-8 pb-0">
+              <CardTitle className="text-lg font-semibold">Linked cards</CardTitle>
+              {accountRows.length > 1 ? (
+                <CardDescription>
+                  Select cards to filter your insights. Currently viewing: {selectedCardsText}.
+                </CardDescription>
+              ) : null}
+            </CardHeader>
+            <CardContent className="p-6 md:p-8 pt-4">
+              {accounts.isLoading ? (
+                <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">Loading cards…</div>
+              ) : accountRows.length ? (
+                <div className="space-y-3">
+                  {accountRows.length > 1 ? (
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleSelectAllCards}
+                        disabled={selectedCardIds.length === accountRows.length}
+                      >
+                        Select all
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={handleClearSelection} disabled={selectedCardIds.length === 0}>
+                        Clear
+                      </Button>
+                    </div>
+                  ) : null}
+                  <div className="space-y-2">
+                    {accountRows.map((card) => (
+                      <div
+                        key={card.id}
+                        className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 px-4 py-3"
+                      >
+                        {accountRows.length > 1 ? (
+                          <Checkbox
+                            checked={selectedCardIds.includes(card.id)}
+                            onCheckedChange={() => handleCardToggle(card.id)}
+                          />
+                        ) : null}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-foreground md:text-base">{card.nickname}</p>
+                          <p className="text-xs text-muted-foreground">{card.issuer} •••• {card.mask}</p>
+                          <p className="text-xs text-muted-foreground">{formatLastSynced(card)}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            ))
-          ) : (
-            <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
-              No cards yet. Add your first card to get insights.
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card className="md:col-span-12 min-h-[10rem] rounded-3xl">
-        <CardHeader>
-          <CardTitle className="text-lg font-semibold">Money moments</CardTitle>
-        </CardHeader>
-        <CardContent className="grid h-40 grid-cols-1 gap-3 overflow-auto px-0 pb-0 sm:grid-cols-2 md:grid-cols-4">
-          {moments.isLoading ? (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Loading insights…</div>
-          ) : momentsList.length ? (
-            momentsList.map((moment) => <MoneyMomentCard key={moment.id} moment={moment} />)
-          ) : (
-            <div className="flex h-full items-center justify-center px-6 text-sm text-muted-foreground">
-              We’ll highlight tips and wins here.
-            </div>
-          )}
-        </CardContent>
-      </Card>
+              ) : (
+                <div className="flex h-40 items-center justify-center text-center text-sm text-muted-foreground">
+                  No cards yet. Add your first card to get insights.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
     </div>
   )
 
   const detailsContent = (
-    <Card className="rounded-3xl">
-      <CardHeader>
-        <CardTitle className="text-lg font-semibold">Detailed breakdown</CardTitle>
-        <CardDescription>
-          We’re preparing an expanded table with every category, percentage, and export option.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4 text-sm text-muted-foreground">
-        <p>
-          Soon you’ll be able to inspect every category, sort by amount, and download your spending data. This view will also let
-          you compare time ranges and card combinations.
-        </p>
-        <div className="rounded-2xl border border-dashed border-border/70 bg-muted/30 p-4">
-          <p className="font-medium text-foreground">Coming soon</p>
-          <p>Interactive category analytics, filters, and CSV export.</p>
-        </div>
-      </CardContent>
-    </Card>
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+      <DetailsTable
+        data={detailCategories}
+        total={detailTotal}
+        windowDays={DETAILS_WINDOW_DAYS}
+        transactionCount={detailTransactions}
+        isLoading={spendDetails.isLoading}
+      />
+      <MerchantDetailsTable data={detailMerchants} isLoading={spendDetails.isLoading} />
+    </div>
   )
 
   const recommendationsContent = (
-    <Card className="rounded-3xl">
-      <CardHeader>
-        <CardTitle className="text-lg font-semibold">Card recommendations</CardTitle>
-        <CardDescription>
-          We’ll highlight the best cards and cashback tips for your spending habits right here.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4 text-sm text-muted-foreground">
-        {topCategory ? (
-          <p>
-            Looks like <span className="font-semibold text-foreground">{topCategory.name}</span> has led your spending at
-            {" "}
-            {currencyFormatter.format(topCategory.total)} over the last 30 days. We’ll use that to tailor smarter card matches.
-          </p>
-        ) : (
-          <p>As soon as you add some spend, we’ll surface ways to earn more rewards.</p>
-        )}
-        <div className="rounded-2xl border border-dashed border-border/70 bg-muted/30 p-4">
-          <p className="font-medium text-foreground">Preview</p>
-          <p>Expect personalised cashback tips and curated product suggestions in the next sprint.</p>
-        </div>
-      </CardContent>
-    </Card>
+    <RecommendationsSection
+      categories={detailCategories}
+      total={detailTotal}
+      windowDays={DETAILS_WINDOW_DAYS}
+      isLoadingDetails={spendDetails.isLoading}
+      catalogSize={catalog.data?.length}
+    />
   )
 
   const tabContent =
-    activeTab === "overview" ? overviewContent : activeTab === "details" ? detailsContent : recommendationsContent
+    activeTab === "overview"
+      ? overviewContent
+      : activeTab === "details"
+        ? detailsContent
+        : recommendationsContent
 
   return (
-    <div className="space-y-10">
+    <div className="mx-auto max-w-7xl px-4 md:px-6 lg:px-8 space-y-10">
       <PageSection
         title={`Welcome back, ${greeting}`}
-        description="Here’s what’s been happening across your wallet over the last 30 days."
+        description={`Here’s what’s been happening across your wallet over the last ${DETAILS_WINDOW_DAYS} days.`}
         actions={
           <div className="flex flex-wrap gap-2">
             <Button asChild variant="secondary">
@@ -286,7 +292,7 @@ export function HomePage() {
       />
 
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex gap-2 rounded-full border border-border/60 bg-white/70 p-1 text-sm shadow-sm backdrop-blur dark:bg-zinc-900/60">
+        <div className="flex gap-2 rounded-full border border-border/60 bg-white/80 p-1 text-sm shadow-sm backdrop-blur dark:bg-zinc-900/60">
           {HOME_TABS.map((tab) => {
             const isActive = tab.id === activeTab
             const baseClasses = "rounded-full px-4 py-1.5 text-sm font-medium transition focus:outline-none"
@@ -306,7 +312,8 @@ export function HomePage() {
         </div>
       </div>
 
-      <div className="space-y-6">{tabContent}</div>
+      <div className="space-y-8">{tabContent}</div>
     </div>
   )
 }
+

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -27,6 +27,29 @@ export type MerchantRow = {
   logoUrl?: string
 }
 
+export type SpendDetailCategory = {
+  key: string
+  amount: number
+  count: number
+  pct: number
+}
+
+export type SpendDetailMerchant = {
+  name: string
+  category: string
+  amount: number
+  count: number
+  logoUrl?: string
+}
+
+export type SpendDetails = {
+  windowDays: number
+  total: number
+  transactionCount: number
+  categories: SpendDetailCategory[]
+  merchants: SpendDetailMerchant[]
+}
+
 export type MoneyMoment = {
   id: string
   title: string
@@ -57,4 +80,84 @@ export type CardDetails = CardRow & {
   productName?: string
   features?: string[]
   summary?: CardSummary
+}
+
+export type CreditCardReward = {
+  category: string
+  rate: number
+  cap_monthly?: number | null
+}
+
+export type WelcomeOffer = {
+  bonus_value_usd?: number
+  min_spend?: number
+  window_days?: number
+} | null
+
+export type CreditCardProduct = {
+  id: string | null
+  slug: string
+  product_name: string
+  issuer: string
+  network?: string | null
+  annual_fee: number
+  base_cashback: number
+  rewards: CreditCardReward[]
+  welcome_offer: WelcomeOffer
+  foreign_tx_fee: number
+  link_url?: string | null
+  active: boolean
+  last_updated?: string | null
+}
+
+export type RecommendationBonusBreakdown = {
+  category: string
+  rate: number
+  cap_monthly?: number | null
+  eligible_spend_monthly: number
+  monthly_amount: number
+  annual_amount: number
+}
+
+export type RecommendationBreakdown = {
+  monthly_spend: number
+  base: {
+    rate: number
+    monthly_amount: number
+    annual_amount: number
+  }
+  bonuses: RecommendationBonusBreakdown[]
+  welcome: {
+    value: number
+    min_spend?: number
+    window_days?: number
+  } | null
+}
+
+export type RecommendationCard = {
+  id: string | null
+  slug?: string | null
+  product_name?: string
+  issuer?: string
+  network?: string | null
+  link_url?: string | null
+  foreign_tx_fee?: number | null
+  base_cashback: number
+  annual_fee: number
+  annual_reward: number
+  monthly_reward: number
+  net: number
+  active: boolean
+  rewards: CreditCardReward[]
+  welcome_offer: WelcomeOffer
+  breakdown: RecommendationBreakdown
+  highlights: string[]
+}
+
+export type RecommendationResponse = {
+  mix: Record<string, number>
+  monthly_spend: number
+  windowDays: number
+  cards: RecommendationCard[]
+  explanation: string
 }

--- a/server/.env
+++ b/server/.env
@@ -1,0 +1,3 @@
+# Copy this file locally and populate secrets.
+GEMINI_API_KEY=
+

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,2 @@
+"""Swipe Coach server package."""
+

--- a/server/llm/__init__.py
+++ b/server/llm/__init__.py
@@ -1,0 +1,2 @@
+"""Language model helpers."""
+

--- a/server/llm/gemini.py
+++ b/server/llm/gemini.py
@@ -1,0 +1,65 @@
+"""Gemini helper utilities for generating explanations."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterable
+
+import requests
+
+
+MODEL = "gemini-2.5-flash"
+BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+
+
+def _build_endpoint(api_key: str) -> str:
+    return f"{BASE_URL}/{MODEL}:generateContent?key={api_key}"
+
+
+def _format_prompt(user_mix: Dict[str, float], card_names: Iterable[str]) -> Dict[str, object]:
+    cards_list = ", ".join(card_names)
+    prompt_text = (
+        "User category mix (percent of monthly spend): "
+        f"{user_mix}. Give 3 short bullets explaining why these cards fit: "
+        f"{cards_list}. Avoid exact APRs/terms; keep generic."
+    )
+    return {"contents": [{"parts": [{"text": prompt_text}]}]}
+
+
+def explain_recommendations(user_mix: Dict[str, float], card_names: Iterable[str]) -> str:
+    """Return a brief explanation for the recommended cards.
+
+    The Gemini API is optional—if a key is not configured or the request fails we simply
+    return an empty string so the deterministic scoring still works.
+    """
+
+    card_names = list(card_names)
+    if not card_names:
+        return ""
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return ""
+
+    try:
+        response = requests.post(
+            _build_endpoint(api_key),
+            json=_format_prompt(user_mix, card_names),
+            timeout=15,
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        return ""
+
+    try:
+        data = response.json()
+    except ValueError:
+        return ""
+
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"].strip()
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+    return text
+

--- a/server/services/__init__.py
+++ b/server/services/__init__.py
@@ -1,0 +1,2 @@
+"""Shared service helpers."""
+

--- a/server/services/scoring.py
+++ b/server/services/scoring.py
@@ -1,0 +1,176 @@
+"""Deterministic credit card scoring utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Sequence
+
+
+def _format_rewards(rewards: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    formatted: List[Dict[str, Any]] = []
+    for reward in rewards or []:
+        category = reward.get("category")
+        rate = reward.get("rate")
+        if not category or rate is None:
+            continue
+        entry: Dict[str, Any] = {
+            "category": str(category),
+            "rate": float(rate),
+        }
+        if reward.get("cap_monthly") is not None:
+            try:
+                entry["cap_monthly"] = float(reward["cap_monthly"])
+            except (TypeError, ValueError):
+                pass
+        formatted.append(entry)
+    return formatted
+
+
+def _format_welcome_offer(offer: Dict[str, Any] | None) -> Dict[str, Any] | None:
+    if not offer:
+        return None
+    formatted: Dict[str, Any] = {}
+    if offer.get("bonus_value_usd") is not None:
+        try:
+            formatted["bonus_value_usd"] = float(offer["bonus_value_usd"])
+        except (TypeError, ValueError):
+            pass
+    if offer.get("min_spend") is not None:
+        try:
+            formatted["min_spend"] = float(offer["min_spend"])
+        except (TypeError, ValueError):
+            pass
+    if offer.get("window_days") is not None:
+        try:
+            formatted["window_days"] = int(offer["window_days"])
+        except (TypeError, ValueError):
+            pass
+    return formatted or None
+
+
+def score_card(
+    card: Dict[str, Any],
+    category_mix: Dict[str, float],
+    monthly_total: float,
+    window_days: int,
+) -> Dict[str, Any]:
+    base_rate = float(card.get("base_cashback") or 0.0)
+    base_reward_monthly = base_rate * monthly_total
+
+    rewards = _format_rewards(card.get("rewards", []))
+    bonus_details: List[Dict[str, Any]] = []
+    bonus_total_monthly = 0.0
+    for reward in rewards:
+        category = reward["category"]
+        rate = reward["rate"]
+        bonus_rate = max(rate - base_rate, 0.0)
+        category_share = category_mix.get(category, 0.0)
+        category_spend = monthly_total * category_share
+        cap = reward.get("cap_monthly")
+        eligible_spend = min(category_spend, cap) if isinstance(cap, (int, float)) else category_spend
+        bonus_amount = bonus_rate * eligible_spend
+        bonus_total_monthly += bonus_amount
+        bonus_details.append(
+            {
+                "category": category,
+                "rate": rate,
+                "cap_monthly": cap,
+                "eligible_spend_monthly": round(eligible_spend, 2),
+                "monthly_amount": round(bonus_amount, 2),
+                "annual_amount": round(bonus_amount * 12, 2),
+            }
+        )
+
+    monthly_reward = base_reward_monthly + bonus_total_monthly
+    annual_reward = monthly_reward * 12
+
+    welcome_offer = _format_welcome_offer(card.get("welcome_offer"))
+    welcome_value = 0.0
+    if welcome_offer:
+        bonus_value = float(welcome_offer.get("bonus_value_usd") or 0.0)
+        min_spend = float(welcome_offer.get("min_spend") or 0.0)
+        offer_window = int(welcome_offer.get("window_days") or window_days or 0)
+        if bonus_value > 0:
+            if min_spend > 0 and monthly_total > 0 and offer_window > 0:
+                spend_available = monthly_total * (offer_window / 30)
+                progress = min(spend_available / min_spend, 1.0)
+                welcome_value = bonus_value * progress
+            else:
+                welcome_value = bonus_value
+        annual_reward += welcome_value
+    else:
+        welcome_offer = None
+
+    annual_fee = float(card.get("annual_fee") or 0.0)
+    net_value = annual_reward - annual_fee
+
+    highlights: List[str] = []
+    for bonus in sorted(bonus_details, key=lambda item: item["monthly_amount"], reverse=True):
+        if bonus["monthly_amount"] <= 0:
+            continue
+        highlights.append(
+            f"{bonus['rate'] * 100:.1f}% back on {bonus['category']} up to ${bonus['eligible_spend_monthly']:.0f}/mo"
+        )
+    if welcome_value > 0 and welcome_offer:
+        offer_window = welcome_offer.get("window_days") or window_days
+        min_spend = welcome_offer.get("min_spend")
+        spend_text = f"${min_spend:,.0f}" if isinstance(min_spend, (int, float)) and min_spend else "the required amount"
+        highlights.append(
+            f"Intro bonus worth ~${welcome_value:,.0f} if you spend {spend_text} in {offer_window} days"
+        )
+    if not highlights and base_rate > 0 and monthly_total > 0:
+        highlights.append(
+            f"{base_rate * 100:.1f}% back on about ${monthly_total:,.0f} in monthly spend"
+        )
+
+    return {
+        "id": str(card.get("_id")) if card.get("_id") else None,
+        "slug": card.get("slug"),
+        "product_name": card.get("product_name"),
+        "issuer": card.get("issuer"),
+        "network": card.get("network"),
+        "link_url": card.get("link_url"),
+        "foreign_tx_fee": card.get("foreign_tx_fee"),
+        "base_cashback": base_rate,
+        "annual_fee": annual_fee,
+        "annual_reward": round(annual_reward, 2),
+        "monthly_reward": round(monthly_reward, 2),
+        "net": round(net_value, 2),
+        "active": bool(card.get("active", True)),
+        "rewards": rewards,
+        "welcome_offer": welcome_offer,
+        "breakdown": {
+            "monthly_spend": round(monthly_total, 2),
+            "base": {
+                "rate": base_rate,
+                "monthly_amount": round(base_reward_monthly, 2),
+                "annual_amount": round(base_reward_monthly * 12, 2),
+            },
+            "bonuses": bonus_details,
+            "welcome": {
+                "value": round(welcome_value, 2),
+                "min_spend": welcome_offer.get("min_spend") if welcome_offer else None,
+                "window_days": welcome_offer.get("window_days") if welcome_offer else None,
+            }
+            if welcome_value > 0
+            else None,
+        },
+        "highlights": highlights,
+    }
+
+
+def score_catalog(
+    cards: Sequence[Dict[str, Any]],
+    category_mix: Dict[str, float],
+    monthly_total: float,
+    window_days: int,
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    if monthly_total <= 0 or not category_mix:
+        return []
+
+    scored = [score_card(card, category_mix, monthly_total, window_days) for card in cards]
+    scored.sort(key=lambda item: item["net"], reverse=True)
+    if limit > 0:
+        return scored[:limit]
+    return scored
+

--- a/server/services/spend.py
+++ b/server/services/spend.py
@@ -1,0 +1,149 @@
+"""Helpers for analysing spend data."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import re
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from bson import ObjectId
+
+
+def load_transactions(
+    database,
+    user_id: ObjectId,
+    window_days: int,
+    card_object_ids: Optional[Sequence[ObjectId]] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch transactions for the given user and time window."""
+
+    cutoff = datetime.utcnow() - timedelta(days=window_days)
+    query: Dict[str, Any] = {"userId": user_id, "date": {"$gte": cutoff}}
+    if card_object_ids:
+        query["accountId"] = {"$in": list(card_object_ids)}
+    return list(database["transactions"].find(query))
+
+
+def _summarize_categories(transactions: Iterable[Dict[str, Any]]) -> Tuple[float, Dict[str, float], Dict[str, int]]:
+    total = 0.0
+    by_category: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    for txn in transactions:
+        raw_amount = float(txn.get("amount", 0) or 0)
+        amount = max(raw_amount, 0.0)
+        category = txn.get("category") or "Uncategorized"
+        by_category[category] = by_category.get(category, 0.0) + amount
+        counts[category] = counts.get(category, 0) + 1
+        total += amount
+    return total, by_category, counts
+
+
+def compute_user_mix(
+    database,
+    user_id: ObjectId,
+    window_days: int,
+    card_object_ids: Optional[Sequence[ObjectId]] = None,
+    transactions: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[Dict[str, float], float, List[Dict[str, Any]]]:
+    """Return the user category mix and total spend for the given window."""
+
+    if transactions is None:
+        transactions = load_transactions(database, user_id, window_days, card_object_ids)
+
+    total, by_category, _ = _summarize_categories(transactions)
+    if total <= 0:
+        return {}, 0.0, transactions
+
+    mix = {category: amount / total for category, amount in by_category.items() if amount > 0}
+    return mix, total, transactions
+
+
+def build_category_rules(mappings: Iterable[Dict[str, Any]]) -> List[Tuple[str, Any, str]]:
+    """Compile merchant category mapping rules from the database."""
+
+    rules: List[Tuple[str, Any, str]] = []
+    for mapping in mappings:
+        pattern = mapping.get("pattern")
+        category = mapping.get("category")
+        if not pattern or not category:
+            continue
+        try:
+            rules.append(("regex", re.compile(pattern, re.IGNORECASE), category))
+        except re.error:
+            rules.append(("substr", str(pattern).lower(), category))
+    return rules
+
+
+def _resolve_category(name: str, fallback: str, rules: Optional[Sequence[Tuple[str, Any, str]]]) -> str:
+    if not rules:
+        return fallback
+    lowered = name.lower()
+    for rule_type, matcher, category in rules:
+        if rule_type == "regex":
+            if matcher.search(name):  # type: ignore[attr-defined]
+                return category
+        else:
+            if matcher in lowered:
+                return category
+    return fallback
+
+
+def aggregate_spend_details(
+    transactions: List[Dict[str, Any]],
+    category_rules: Optional[Sequence[Tuple[str, Any, str]]] = None,
+) -> Dict[str, Any]:
+    """Produce a detailed breakdown of categories and merchants."""
+
+    total, by_category, counts = _summarize_categories(transactions)
+
+    categories = [
+        {
+            "key": category,
+            "amount": round(amount, 2),
+            "count": counts.get(category, 0),
+            "pct": (amount / total) if total else 0.0,
+        }
+        for category, amount in sorted(by_category.items(), key=lambda item: item[1], reverse=True)
+    ]
+
+    merchants: Dict[str, Dict[str, Any]] = {}
+    for txn in transactions:
+        raw_amount = float(txn.get("amount", 0) or 0)
+        amount = max(raw_amount, 0.0)
+        if amount <= 0:
+            continue
+        name = (
+            txn.get("merchant_id")
+            or txn.get("description_clean")
+            or txn.get("description")
+            or "Merchant"
+        )
+        base_category = txn.get("category") or "General"
+        merchant = merchants.setdefault(
+            name,
+            {
+                "name": name,
+                "category": base_category,
+                "count": 0,
+                "amount": 0.0,
+                "logoUrl": txn.get("logoUrl", ""),
+            },
+        )
+        merchant["count"] += 1
+        merchant["amount"] += amount
+        if not merchant.get("logoUrl") and txn.get("logoUrl"):
+            merchant["logoUrl"] = txn.get("logoUrl")
+
+    for merchant in merchants.values():
+        merchant["category"] = _resolve_category(merchant["name"], merchant.get("category", "General"), category_rules)
+        merchant["amount"] = round(merchant["amount"], 2)
+
+    merchant_rows = sorted(merchants.values(), key=lambda item: item["amount"], reverse=True)
+
+    return {
+        "total": round(total, 2),
+        "transaction_count": len(transactions),
+        "categories": categories,
+        "merchants": merchant_rows,
+    }
+


### PR DESCRIPTION
## Summary
- add Mongo-backed catalog scoring service with new spend details and recommendations endpoints
- integrate optional Gemini explanations and expose catalog management routes
- redesign home and cards pages with details, recommendations, and catalog tabs plus spacing updates

## Testing
- npm run build
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ceeb843b388326b96d389f8d6619fa