### PR TITLE
Add card application logging and Gemini chat assistant

### DIFF
--- a/client/src/components/cards/CardRow.tsx
+++ b/client/src/components/cards/CardRow.tsx
@@ -1,6 +1,5 @@
-import { KeyboardEvent } from "react"
+import type { KeyboardEvent } from "react"
 import { Button } from "@/components/ui/button"
-import { Card as UICard } from "@/components/ui/card" // (optional, not used but handy if you want wrappers)
 import { Pencil, Trash2 } from "lucide-react"
 import type { CardRow as CardRowType } from "@/types/api" // avoid name clash with component
 
@@ -22,11 +21,10 @@ export default function CardRow({ card, isSelected = false, onSelect, onEdit, on
 
     const title =
         card.nickname ||
-        card.productName ||
         [card.issuer, card.network].filter(Boolean).join(" ") ||
         "Credit card"
 
-    const mask = card.account_mask ? `•••• ${card.account_mask}` : "•••• •••• •••• ••••"
+    const mask = card.mask ? `•••• ${card.mask}` : "•••• •••• •••• ••••"
     const expires = card.expires ? `Exp ${card.expires}` : undefined
 
     return (

--- a/client/src/components/chat/FlowCoachChat.tsx
+++ b/client/src/components/chat/FlowCoachChat.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from "react"
+import { MessageCircle, Send, Sparkles } from "lucide-react"
+
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+import { useChat } from "@/hooks/useChat"
+import type { ChatMessage } from "@/types/api"
+
+const suggestionChips = ["Why this card?", "3 quick wins", "Summarize 30 days", "How do I lower travel?"]
+
+const initialMessage: ChatMessage = {
+  id: "welcome",
+  author: "assistant",
+  content: "Hey Avery! Curious about your subscriptions or want three quick wins?",
+  timestamp: new Date().toISOString(),
+}
+
+export function FlowCoachChatWidget() {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [input, setInput] = useState("")
+  const [messages, setMessages] = useState<ChatMessage[]>([initialMessage])
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const chat = useChat()
+  const isSending = chat.isPending
+
+  useEffect(() => {
+    if (!open) return
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" })
+  }, [messages, open])
+
+  const appendAssistantMessage = (message: ChatMessage | undefined) => {
+    if (!message) {
+      return
+    }
+    setMessages((prev) => [
+      ...prev,
+      {
+        ...message,
+        id: message.id ?? crypto.randomUUID(),
+        timestamp: message.timestamp ?? new Date().toISOString(),
+      },
+    ])
+  }
+
+  const sendMessage = (text: string) => {
+    const trimmed = text.trim()
+    if (!trimmed || isSending) {
+      return
+    }
+
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      author: "user",
+      content: trimmed,
+      timestamp: new Date().toISOString(),
+    }
+
+    setMessages((prev) => [...prev, userMessage])
+    setInput("")
+
+    toast({
+      title: "Flow Coach is thinking",
+      description: "Live Gemini-powered responses are on the way.",
+    })
+
+    const history = messages.map(({ author, content, timestamp }) => ({ author, content, timestamp }))
+
+    chat.mutate(
+      { history, newMessage: trimmed },
+      {
+        onSuccess: (data) => {
+          appendAssistantMessage(data?.message)
+        },
+        onError: (error) => {
+          toast({
+            title: "Chat is unavailable",
+            description: error.message,
+          })
+        },
+      }
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          size="lg"
+          className="fixed bottom-6 right-6 z-50 flex h-12 items-center gap-2 rounded-full bg-primary px-5 text-primary-foreground shadow-soft hover:bg-primary/90"
+        >
+          <MessageCircle className="h-4 w-4" />
+          Flow Coach
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex w-full flex-col bg-gradient-to-b from-background/95 to-background sm:max-w-md">
+        <div className="flex h-full flex-col gap-6">
+          <Card className="flex h-full flex-col rounded-3xl shadow-xl">
+            <CardHeader className="flex flex-row items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/20 text-primary">
+                  <MessageCircle className="h-4 w-4" />
+                </span>
+                <CardTitle className="text-lg font-semibold">Flow Coach</CardTitle>
+              </div>
+              <Badge variant="outline" className="gap-1">
+                <Sparkles className="h-3.5 w-3.5" />
+                Beta
+              </Badge>
+            </CardHeader>
+            <CardContent className="flex h-full flex-col space-y-4">
+              <div className="flex flex-wrap gap-2">
+                {suggestionChips.map((chip) => (
+                  <button
+                    key={chip}
+                    type="button"
+                    className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted/80"
+                    onClick={() => sendMessage(chip)}
+                    disabled={isSending}
+                  >
+                    {chip}
+                  </button>
+                ))}
+              </div>
+              <div
+                ref={listRef}
+                className="glass-panel flex-1 space-y-4 overflow-y-auto rounded-3xl bg-white/70 p-6 dark:bg-zinc-900/50"
+              >
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={
+                      message.author === "assistant"
+                        ? "max-w-[80%] rounded-3xl bg-primary/10 p-4 text-sm"
+                        : "ml-auto max-w-[80%] rounded-3xl bg-primary p-4 text-sm text-primary-foreground shadow-soft"
+                    }
+                  >
+                    {message.content}
+                  </div>
+                ))}
+              </div>
+              <form
+                className="flex items-center gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  sendMessage(input)
+                }}
+              >
+                <Input
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  placeholder="Ask Flow Coach anything"
+                  disabled={isSending}
+                />
+                <Button type="submit" size="icon" className="h-11 w-11" disabled={isSending}>
+                  <Send className="h-4 w-4" />
+                  <span className="sr-only">Send</span>
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "./ThemeToggle"
 import { useMe } from "@/hooks/useApi"
 import { authConfig } from "@/lib/env"
+import { FlowCoachChatWidget } from "@/components/chat/FlowCoachChat"
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const auth = authConfig.disableAuth ? null : useAuth0()
@@ -85,6 +86,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </section>
         <div className="space-y-8">{children}</div>
       </main>
+      <FlowCoachChatWidget />
     </div>
   )
 }

--- a/client/src/hooks/useCards.ts
+++ b/client/src/hooks/useCards.ts
@@ -93,3 +93,24 @@ export function useDeleteCard(options?: MutationOpts<void, string>) {
     ...rest,
   })
 }
+
+type ApplicationPayload = {
+  slug: string
+  product_name: string
+  issuer: string
+}
+
+export function useApplyForCard(options?: MutationOpts<{ status: string; id: string }, ApplicationPayload>) {
+  const { onSuccess, ...rest } = options ?? {}
+  return useMutation({
+    mutationFn: (payload: ApplicationPayload) =>
+      apiFetch<{ status: string; id: string }>("/applications", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, onMutateResult, context) => {
+      onSuccess?.(data, variables, onMutateResult, context)
+    },
+    ...rest,
+  })
+}

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1,0 +1,22 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query"
+
+import { apiFetch } from "@/lib/api-client"
+import type { ChatMessage, ChatResponse } from "@/types/api"
+
+type ChatPayload = {
+  history: Pick<ChatMessage, "author" | "content" | "timestamp">[]
+  newMessage: string
+}
+
+type Options = Omit<UseMutationOptions<ChatResponse, Error, ChatPayload, unknown>, "mutationFn">
+
+export function useChat(options?: Options) {
+  return useMutation({
+    mutationFn: (payload: ChatPayload) =>
+      apiFetch<ChatResponse>("/chat", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    ...options,
+  })
+}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -161,3 +161,14 @@ export type RecommendationResponse = {
   cards: RecommendationCard[]
   explanation: string
 }
+
+export type ChatMessage = {
+  id?: string
+  author: "user" | "assistant"
+  content: string
+  timestamp: string
+}
+
+export type ChatResponse = {
+  message: ChatMessage
+}

--- a/server/llm/gemini.py
+++ b/server/llm/gemini.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Sequence
 
 import requests
 
@@ -62,4 +62,95 @@ def explain_recommendations(user_mix: Dict[str, float], card_names: Iterable[str
         return ""
 
     return text
+
+
+def _format_spend_mix(spend_mix: Dict[str, float]) -> str:
+    if not spend_mix:
+        return "No recent spend mix available."
+    parts = []
+    for category, share in sorted(spend_mix.items(), key=lambda item: item[1], reverse=True):
+        parts.append(f"{category}: {share * 100:.1f}%")
+    return ", ".join(parts)
+
+
+def _format_recommendations(recommendations: Sequence[Dict[str, object]]) -> str:
+    if not recommendations:
+        return "No personalized card recommendations yet."
+    lines: List[str] = []
+    for card in recommendations:
+        name = str(card.get("product_name") or card.get("slug") or "Card")
+        issuer = card.get("issuer")
+        net_value = card.get("net")
+        highlight = card.get("highlights")
+        summary_bits = [name]
+        if issuer:
+            summary_bits.append(f"by {issuer}")
+        if isinstance(net_value, (int, float)):
+            summary_bits.append(f"est. net ${float(net_value):,.0f}/yr")
+        if isinstance(highlight, list) and highlight:
+            summary_bits.append(f"key perk: {highlight[0]}")
+        lines.append(" • ".join(summary_bits))
+    return "\n".join(lines)
+
+
+def _build_chat_payload(system_prompt: str, history: Sequence[Dict[str, str]], new_message: str) -> Dict[str, object]:
+    contents: List[Dict[str, object]] = []
+    for message in history:
+        author = message.get("author")
+        content = message.get("content")
+        if not content:
+            continue
+        role = "user" if author == "user" else "model"
+        contents.append({"role": role, "parts": [{"text": str(content)}]})
+    contents.append({"role": "user", "parts": [{"text": new_message}]})
+
+    return {
+        "system_instruction": {"parts": [{"text": system_prompt}]},
+        "contents": contents,
+    }
+
+
+def generate_chat_response(
+    user_spend_mix: Dict[str, float],
+    recommendations: Sequence[Dict[str, object]],
+    history: Sequence[Dict[str, str]],
+    new_message: str,
+) -> str:
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return "Chat is currently unavailable."
+
+    spend_mix_text = _format_spend_mix(user_spend_mix)
+    recommendations_text = _format_recommendations(recommendations)
+
+    system_prompt = (
+        "You are FinBot, a friendly assistant for the Swipe Coach app."
+        " Help users make sense of their spending and card recommendations."
+        " Do not provide financial advice or instructions that require a professional."
+        " Keep responses concise, specific, and easy to scan.\n\n"
+        "User context:\n"
+        f"• Spending mix (last 90 days): {spend_mix_text}\n"
+        f"• Top card recommendations: {recommendations_text}\n\n"
+        "Respond in a helpful, encouraging tone."
+    )
+
+    payload = _build_chat_payload(system_prompt, history, new_message)
+
+    try:
+        response = requests.post(_build_endpoint(api_key), json=payload, timeout=20)
+        response.raise_for_status()
+    except requests.RequestException:
+        return "I’m still syncing your finances—try again in a moment."
+
+    try:
+        data = response.json()
+    except ValueError:
+        return "I had trouble reading that response. Please try again."
+
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"].strip()
+    except (KeyError, IndexError, TypeError):
+        return "I didn’t catch that—mind asking again?"
+
+    return text or "Let’s try that again with a different question."
 


### PR DESCRIPTION
## Summary
- add an applications collection plus POST /api/applications and /api/chat endpoints that feed Gemini with user spend and recommendations
- build a Gemini prompt helper and a Flow Coach chat widget with a shared useChat mutation hook available across the app shell
- wire catalog cards to log applications through a dedicated mutation and clean up CardRow typing for stricter builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf066324ec8326bcc962e44c0be9d5