### PR TITLE
Add chat assistant and card application endpoints

### DIFF
--- a/client/src/components/chat/ChatWidget.tsx
+++ b/client/src/components/chat/ChatWidget.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from "react"
+import { MessageCircle, Send, Sparkles } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { useToast } from "@/components/ui/use-toast"
+import { useChat } from "@/hooks/useChat"
+import type { ChatMessage } from "@/types/api"
+
+const suggestionChips = [
+  "Why this card?",
+  "3 quick wins",
+  "Summarize 30 days",
+  "How do I lower travel?",
+]
+
+function generateId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+const initialMessage: ChatMessage = {
+  id: "welcome",
+  author: "assistant",
+  content: "Hey there! Curious about your subscriptions or want three quick wins?",
+  timestamp: new Date().toISOString(),
+}
+
+function createUserMessage(content: string): ChatMessage {
+  return {
+    id: generateId(),
+    author: "user",
+    content,
+    timestamp: new Date().toISOString(),
+  }
+}
+
+function createAssistantMessage(content: string, timestamp?: string): ChatMessage {
+  return {
+    id: generateId(),
+    author: "assistant",
+    content,
+    timestamp: timestamp ?? new Date().toISOString(),
+  }
+}
+
+export function ChatWidget() {
+  const { toast } = useToast()
+  const [open, setOpen] = useState(false)
+  const [input, setInput] = useState("")
+  const [messages, setMessages] = useState<ChatMessage[]>([initialMessage])
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const chatMutation = useChat()
+
+  useEffect(() => {
+    if (!open) return
+    listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" })
+  }, [messages, open])
+
+  const isThinking = chatMutation.isPending
+
+  const handleSend = (raw: string) => {
+    const text = raw.trim()
+    if (!text || isThinking) return
+
+    const userMessage = createUserMessage(text)
+    const nextHistory = [...messages, userMessage]
+    setMessages(nextHistory)
+    setInput("")
+
+    chatMutation.mutate(
+      { history: nextHistory, message: userMessage },
+      {
+        onSuccess: (data) => {
+          const reply = data.reply?.trim()
+          const assistantMessage = createAssistantMessage(
+            reply && reply.length > 0 ? reply : "Flow Coach is still thinking—try asking again in a moment.",
+            data.timestamp,
+          )
+          setMessages((prev) => [...prev, assistantMessage])
+        },
+        onError: (error) => {
+          toast({
+            title: "Flow Coach is offline",
+            description: error.message || "Please try again shortly.",
+          })
+          setMessages((prev) => [
+            ...prev,
+            createAssistantMessage("Flow Coach ran into a hiccup. Please try again shortly."),
+          ])
+        },
+      },
+    )
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button className="fixed bottom-6 right-6 z-40 h-12 rounded-full px-5 shadow-xl" size="lg">
+          <MessageCircle className="mr-2 h-5 w-5" />
+          Flow Coach
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="sm:max-w-xl">
+        <div className="flex h-full flex-col gap-4">
+          <Card className="flex h-full flex-col rounded-3xl shadow-xl">
+            <CardHeader className="flex flex-row items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/20 text-primary">
+                  <MessageCircle className="h-4 w-4" />
+                </span>
+                <CardTitle className="text-lg font-semibold">Flow Coach</CardTitle>
+              </div>
+              <Badge variant="outline">Always learning</Badge>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col gap-4">
+              <div className="flex flex-wrap gap-2">
+                {suggestionChips.map((chip) => (
+                  <button
+                    key={chip}
+                    type="button"
+                    onClick={() => {
+                      setInput(chip)
+                      handleSend(chip)
+                    }}
+                    className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted/80"
+                  >
+                    {chip}
+                  </button>
+                ))}
+              </div>
+              <div
+                ref={listRef}
+                className="glass-panel flex-1 space-y-4 overflow-y-auto rounded-3xl border border-border/60 bg-white/70 p-6 dark:bg-zinc-900/60"
+              >
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={
+                      message.author === "assistant"
+                        ? "max-w-[80%] rounded-3xl bg-primary/10 p-4 text-sm"
+                        : "ml-auto max-w-[80%] rounded-3xl bg-primary p-4 text-sm text-primary-foreground shadow-soft"
+                    }
+                  >
+                    {message.content}
+                  </div>
+                ))}
+                {isThinking ? (
+                  <div className="max-w-[80%] rounded-3xl bg-primary/10 p-4 text-xs text-muted-foreground">
+                    Flow Coach is thinking…
+                  </div>
+                ) : null}
+              </div>
+              <form
+                className="flex items-center gap-2"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  handleSend(input)
+                }}
+              >
+                <Input
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  placeholder="Ask Flow Coach anything"
+                  disabled={isThinking}
+                />
+                <Button type="submit" size="icon" className="h-11 w-11" disabled={isThinking}>
+                  <Send className="h-4 w-4" />
+                  <span className="sr-only">Send</span>
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="success" className="gap-1">
+              <Sparkles className="h-3.5 w-3.5" /> Beta
+            </Badge>
+            <span>Gemini-powered responses grounded in your Swipe Coach data.</span>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "./ThemeToggle"
 import { useMe } from "@/hooks/useApi"
 import { authConfig } from "@/lib/env"
+import { ChatWidget } from "@/components/chat/ChatWidget"
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const auth = authConfig.disableAuth ? null : useAuth0()
@@ -85,6 +86,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </section>
         <div className="space-y-8">{children}</div>
       </main>
+      <ChatWidget />
     </div>
   )
 }

--- a/client/src/hooks/useCards.ts
+++ b/client/src/hooks/useCards.ts
@@ -42,6 +42,26 @@ export function useCard(id: string | undefined, options?: QueryOpts<CardDetails 
   })
 }
 
+export function useApplyForCard(
+  options?: MutationOpts<
+    { status: string; applicationId: string },
+    { slug: string; product_name: string; issuer: string }
+  >,
+) {
+  const { onSuccess, ...rest } = options ?? {}
+  return useMutation({
+    mutationFn: (payload: { slug: string; product_name: string; issuer: string }) =>
+      apiFetch<{ status: string; applicationId: string }>("/applications", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    onSuccess: (data, variables, onMutateResult, context) => {
+      onSuccess?.(data, variables, onMutateResult, context)
+    },
+    ...rest,
+  })
+}
+
 export function useAddCard(options?: MutationOpts<{ id: string }, Record<string, unknown>>) {
   const queryClient = useQueryClient()
   const { onSuccess, ...rest } = options ?? {}

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1,0 +1,37 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query"
+
+import { apiFetch } from "@/lib/api-client"
+import type { ChatMessage, ChatResponse } from "@/types/api"
+
+type ChatVariables = {
+  history: ChatMessage[]
+  message: ChatMessage
+}
+
+type MutationOpts<TData, TVariables> = Omit<UseMutationOptions<TData, Error, TVariables, unknown>, "mutationFn">
+
+export function useChat(options?: MutationOpts<ChatResponse, ChatVariables>) {
+  const { onSuccess, ...rest } = options ?? {}
+
+  return useMutation({
+    mutationFn: async ({ history, message }: ChatVariables) => {
+      const payload = {
+        history: history.map(({ author, content, timestamp }) => ({
+          author,
+          content,
+          timestamp,
+        })),
+        newMessage: message.content,
+      }
+
+      return apiFetch<ChatResponse>("/chat", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      })
+    },
+    onSuccess: (data, variables, onMutateResult, context) => {
+      onSuccess?.(data, variables, onMutateResult, context)
+    },
+    ...rest,
+  })
+}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -161,3 +161,15 @@ export type RecommendationResponse = {
   cards: RecommendationCard[]
   explanation: string
 }
+
+export type ChatMessage = {
+  id: string
+  author: "user" | "assistant"
+  content: string
+  timestamp: string
+}
+
+export type ChatResponse = {
+  reply: string
+  timestamp: string
+}

--- a/server/llm/gemini.py
+++ b/server/llm/gemini.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List
 
 import requests
 
@@ -60,6 +60,105 @@ def explain_recommendations(user_mix: Dict[str, float], card_names: Iterable[str
         text = data["candidates"][0]["content"]["parts"][0]["text"].strip()
     except (KeyError, IndexError, TypeError):
         return ""
+
+    return text
+
+
+def _format_spend_mix(user_spend_mix: Dict[str, float]) -> str:
+    if not user_spend_mix:
+        return "No recent spending information."
+    parts = []
+    for category, share in sorted(user_spend_mix.items(), key=lambda item: item[1], reverse=True):
+        try:
+            percent = f"{float(share):.0%}"
+        except (TypeError, ValueError):
+            percent = str(share)
+        parts.append(f"{category}: {percent}")
+    return ", ".join(parts)
+
+
+def _format_recommendations(recommendations: List[Dict[str, object]]) -> str:
+    if not recommendations:
+        return "No card recommendations available yet."
+
+    lines = []
+    for rec in recommendations:
+        name = str(rec.get("product_name") or rec.get("slug") or "Card")
+        issuer = rec.get("issuer")
+        issuer_text = f" ({issuer})" if issuer else ""
+        net = rec.get("net")
+        net_text = ""
+        try:
+            net_value = float(net) if net is not None else None
+        except (TypeError, ValueError):
+            net_value = None
+        if net_value is not None:
+            net_text = f" · est. annual net ${net_value:,.0f}"
+        lines.append(f"- {name}{issuer_text}{net_text}")
+    return "\n".join(lines)
+
+
+def _build_chat_contents(system_prompt: str, history: List[Dict[str, str]], new_message: str) -> Dict[str, object]:
+    conversation_lines: List[str] = []
+    for entry in history:
+        content = str(entry.get("content") or "").strip()
+        if not content:
+            continue
+        author = entry.get("author")
+        speaker = "User" if author == "user" else "FinBot"
+        conversation_lines.append(f"{speaker}: {content}")
+
+    prompt_sections = [system_prompt.strip()]
+    if conversation_lines:
+        prompt_sections.append("Conversation so far:\n" + "\n".join(conversation_lines))
+    prompt_sections.append(f"User: {new_message.strip()}\nFinBot:")
+
+    prompt_text = "\n\n".join(section for section in prompt_sections if section)
+
+    return {"contents": [{"parts": [{"text": prompt_text}]}]}
+
+
+def generate_chat_response(
+    user_spend_mix: Dict[str, float],
+    recommendations: List[Dict[str, object]],
+    history: List[Dict[str, str]],
+    new_message: str,
+) -> str:
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return "Flow Coach chat is currently unavailable."
+
+    system_prompt = f"""
+You are FinBot, a friendly assistant for the Swipe Coach app. Your goal is to help users understand their spending and card recommendations.
+Do not provide financial advice. Keep responses concise and helpful.
+
+User financial context:
+- Spending mix (last 90 days): {_format_spend_mix(user_spend_mix)}
+- Top card recommendations:
+{_format_recommendations(recommendations)}
+
+If information is missing, acknowledge it and offer general guidance about how Swipe Coach can help.
+"""
+
+    try:
+        response = requests.post(
+            _build_endpoint(api_key),
+            json=_build_chat_contents(system_prompt, history, new_message),
+            timeout=20,
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        return "Flow Coach is momentarily offline. Please try again in a bit."
+
+    try:
+        data = response.json()
+    except ValueError:
+        return "Flow Coach couldn't process that just now."
+
+    try:
+        text = data["candidates"][0]["content"]["parts"][0]["text"].strip()
+    except (KeyError, IndexError, TypeError):
+        return "Flow Coach didn't catch that—could you rephrase?"
 
     return text
 


### PR DESCRIPTION
## Summary
- add Mongo initialisation for the applications collection and expose new `/api/applications` and `/api/chat` endpoints that record applications and proxy Gemini responses
- extend the Gemini helper with prompt builders for FinBot conversations grounded in the user mix and recommendations
- add a Flow Coach chat widget, chat mutation hook, and integrate the card catalog apply flow with the new applications API

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated components such as AddCardDialog, CardRow, and BestCardFinder)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2ad2aea48326a6cd0e6008b9e875