### PR TITLE
Add AP2 mandates flow and rewards tooling

### DIFF
--- a/client/src/components/cards/CardRow.tsx
+++ b/client/src/components/cards/CardRow.tsx
@@ -1,6 +1,8 @@
-import { KeyboardEvent } from "react"
-import { Button } from "@/components/ui/button"
+import type { KeyboardEvent } from "react"
 import { Pencil, Trash2 } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import type { CardRow as CardRowType } from "@/types/api"
 
 type Props = {
@@ -53,9 +55,15 @@ export default function CardRow({ card, isSelected = false, onSelect, onEdit, on
                         <span className="truncate text-xs text-muted-foreground">• {issuerNet}</span>
                     ) : null}
                     {card.status ? (
-                        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-              {card.status}
-            </span>
+                        card.status === "Applied" ? (
+                            <Badge variant="success" className="px-2 py-0.5 text-[10px] uppercase">
+                                Applied
+                            </Badge>
+                        ) : (
+                            <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                                {card.status}
+                            </span>
+                        )
                     ) : null}
                 </div>
 

--- a/client/src/components/cards/CardSelector.tsx
+++ b/client/src/components/cards/CardSelector.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react"
+
 import CardRow from "@/components/cards/CardRow"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -12,6 +14,7 @@ type Props = {
     onAdd?: () => void
     isLoading?: boolean
     heightClass?: string
+    headerActions?: ReactNode
 }
 
 export function CardSelector({
@@ -23,17 +26,21 @@ export function CardSelector({
                                  onAdd,
                                  isLoading,
                                  heightClass = "max-h-[760px]", // bumped taller default
+                                 headerActions,
                              }: Props) {
     return (
         <Card className="rounded-3xl">
             <CardHeader className="pb-3">
                 <div className="flex items-center justify-between gap-2">
                     <CardTitle className="text-lg font-semibold">Your cards</CardTitle>
-                    {onAdd ? (
-                        <Button size="sm" onClick={onAdd}>
-                            Add card
-                        </Button>
-                    ) : null}
+                    <div className="flex items-center gap-2">
+                        {headerActions}
+                        {onAdd ? (
+                            <Button size="sm" onClick={onAdd}>
+                                Add card
+                            </Button>
+                        ) : null}
+                    </div>
                 </div>
             </CardHeader>
             <CardContent className="flex h-full flex-col gap-3">

--- a/client/src/components/chat/MandateCard.tsx
+++ b/client/src/components/chat/MandateCard.tsx
@@ -1,0 +1,72 @@
+import { Sparkles } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { MandateAttachment } from "@/types/api"
+
+const STATUS_COPY: Record<MandateAttachment["status"], { label: string; variant: "outline" | "secondary" | "success" }> = {
+  pending_approval: { label: "Awaiting approval", variant: "outline" },
+  approved: { label: "Approved", variant: "secondary" },
+  executed: { label: "Completed", variant: "success" },
+  declined: { label: "Declined", variant: "outline" },
+}
+
+const STATUS_FOOTER: Record<MandateAttachment["status"], string> = {
+  pending_approval: "Approve to continue or decline to skip this action.",
+  approved: "Approved! Flow Coach will handle the next steps shortly.",
+  executed: "All set. We’ve updated your linked cards.",
+  declined: "Declined. Flow Coach will drop this request.",
+}
+
+type MandateCardProps = {
+  mandate: MandateAttachment
+  onApprove: () => void
+  onDecline: () => void
+  isProcessing?: boolean
+}
+
+export function MandateCard({ mandate, onApprove, onDecline, isProcessing = false }: MandateCardProps) {
+  const { status } = mandate
+  const statusInfo = STATUS_COPY[status]
+  const context = mandate.context ?? {}
+
+  const data = mandate.data ?? {}
+  const productName = (context.productName as string) || (data.product_name as string) || (data.productName as string) || "this card"
+  const issuer = (context.issuer as string) || (data.issuer as string) || "the issuer"
+  const description =
+    (context.description as string) ||
+    `Flow Coach will submit the ${productName} application with ${issuer} once you approve.`
+
+  return (
+    <Card className="w-full rounded-3xl border border-primary/30 bg-white/95 p-5 shadow-soft dark:bg-zinc-900/80">
+      <CardHeader className="space-y-3 p-0">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+              <Sparkles className="h-4 w-4" />
+            </span>
+            <CardTitle className="text-base font-semibold">
+              Approve {productName}
+            </CardTitle>
+          </div>
+          <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3 p-0 pt-3 text-sm">
+        {status === "pending_approval" ? (
+          <div className="flex flex-wrap gap-2">
+            <Button size="sm" onClick={onApprove} disabled={isProcessing}>
+              {isProcessing ? "Working…" : "Approve"}
+            </Button>
+            <Button size="sm" variant="outline" onClick={onDecline} disabled={isProcessing}>
+              Decline
+            </Button>
+          </div>
+        ) : null}
+        <p className="text-xs text-muted-foreground">{STATUS_FOOTER[status]}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/client/src/components/ui/toaster.tsx
+++ b/client/src/components/ui/toaster.tsx
@@ -2,20 +2,33 @@ import { ToastProvider, ToastViewport, Toast, ToastTitle, ToastDescription, Toas
 import { useToast } from "./use-toast"
 
 export function Toaster() {
-  const { toasts } = useToast()
+  const { toasts, dismiss } = useToast()
 
   return (
     <ToastProvider swipeDirection="right">
-      {toasts.map(({ id, title, description, action, ...props }) => (
-        <Toast key={id} {...props}>
-          <div className="grid gap-1">
-            {title ? <ToastTitle>{title}</ToastTitle> : null}
-            {description ? <ToastDescription>{description}</ToastDescription> : null}
-          </div>
-          {action}
-          <ToastClose />
-        </Toast>
-      ))}
+      {toasts.map(({ id, title, description, action, ...props }) => {
+        const { onOpenChange, open, ...rest } = props
+        return (
+          <Toast
+            key={id}
+            open={open}
+            onOpenChange={(nextOpen) => {
+              onOpenChange?.(nextOpen)
+              if (!nextOpen) {
+                dismiss(id)
+              }
+            }}
+            {...rest}
+          >
+            <div className="grid gap-1">
+              {title ? <ToastTitle>{title}</ToastTitle> : null}
+              {description ? <ToastDescription>{description}</ToastDescription> : null}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
       <ToastViewport />
     </ToastProvider>
   )

--- a/client/src/lib/flow-coach.ts
+++ b/client/src/lib/flow-coach.ts
@@ -1,0 +1,30 @@
+import type { MandateAttachment, MandateStatus } from "@/types/api"
+
+export const FLOW_COACH_OPEN_EVENT = "flowcoach:open"
+export const FLOW_COACH_MANDATE_EVENT = "flowcoach:mandate"
+export const FLOW_COACH_MANDATE_RESOLVED_EVENT = "flowcoach:mandate:resolved"
+
+export type FlowCoachMandateEventDetail = {
+  message?: string
+  mandate: MandateAttachment
+}
+
+export type FlowCoachMandateResolvedDetail = {
+  id: string
+  status: MandateStatus
+}
+
+export function openFlowCoach() {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent(FLOW_COACH_OPEN_EVENT))
+}
+
+export function pushMandateToFlowCoach(detail: FlowCoachMandateEventDetail) {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent(FLOW_COACH_MANDATE_EVENT, { detail }))
+}
+
+export function notifyMandateResolved(detail: FlowCoachMandateResolvedDetail) {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new CustomEvent(FLOW_COACH_MANDATE_RESOLVED_EVENT, { detail }))
+}

--- a/client/src/lib/mandates.ts
+++ b/client/src/lib/mandates.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from "@/lib/api-client"
+import type { Mandate, MandateStatus } from "@/types/api"
+
+type MandateResponse = {
+  id: string
+  status: MandateStatus
+  type?: Mandate["type"]
+  data?: Record<string, unknown>
+  created_at?: string | null
+  updated_at?: string | null
+  result?: string
+}
+
+type CreateMandatePayload = {
+  type: Mandate["type"]
+  data: Record<string, unknown>
+}
+
+function mapMandate(response: MandateResponse, previous?: Mandate): Mandate {
+  return {
+    id: response.id,
+    type: response.type ?? previous?.type ?? "intent",
+    status: response.status,
+    data: response.data ?? previous?.data ?? {},
+    createdAt: response.created_at ?? previous?.createdAt ?? null,
+    updatedAt: response.updated_at ?? previous?.updatedAt ?? null,
+  }
+}
+
+export async function createMandate(payload: CreateMandatePayload): Promise<Mandate> {
+  const response = await apiFetch<MandateResponse>("/ap2/mandates", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  })
+  return mapMandate(response)
+}
+
+export async function approveMandate(id: string, previous?: Mandate): Promise<Mandate> {
+  const response = await apiFetch<MandateResponse>(`/ap2/mandates/${id}/approve`, {
+    method: "POST",
+  })
+  return mapMandate({ ...previous, ...response, id } as MandateResponse, previous)
+}
+
+export async function declineMandate(id: string, previous?: Mandate): Promise<Mandate> {
+  const response = await apiFetch<MandateResponse>(`/ap2/mandates/${id}/decline`, {
+    method: "POST",
+  })
+  return mapMandate({ ...previous, ...response, id } as MandateResponse, previous)
+}
+
+export async function executeMandate(id: string): Promise<MandateResponse> {
+  return apiFetch<MandateResponse>(`/ap2/mandates/${id}/execute`, {
+    method: "POST",
+  })
+}

--- a/client/src/pages/CardsPage.tsx
+++ b/client/src/pages/CardsPage.tsx
@@ -15,8 +15,15 @@ import { EditCardDialog } from "@/components/cards/EditCardDialog"
 
 import { useToast } from "@/components/ui/use-toast"
 
-import { useCards, useCard, useDeleteCard, useCardCatalog, useApplyForCard } from "@/hooks/useCards"
-import type { CardRow as CardRowType, CreditCardProduct } from "@/types/api"
+import { useCards, useCard, useDeleteCard, useCardCatalog, useRewardsEstimate } from "@/hooks/useCards"
+import { createMandate } from "@/lib/mandates"
+import {
+    FLOW_COACH_MANDATE_RESOLVED_EVENT,
+    openFlowCoach,
+    pushMandateToFlowCoach,
+    type FlowCoachMandateResolvedDetail,
+} from "@/lib/flow-coach"
+import type { CardRow as CardRowType, CreditCardProduct, MandateAttachment } from "@/types/api"
 
 const currency0 = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 })
 const currency2 = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 2 })
@@ -37,6 +44,13 @@ const ANNUAL_FEE_FILTERS = [
 ] as const
 type AnnualFeeFilter = typeof ANNUAL_FEE_FILTERS[number]["value"]
 
+const APPLIED_FILTERS = [
+    { value: "all", label: "All cards" },
+    { value: "applied", label: "Applied only" },
+    { value: "not-applied", label: "Not applied" },
+] as const
+type AppliedFilter = typeof APPLIED_FILTERS[number]["value"]
+
 const PAGE_SIZE = 4
 
 export default function CardsPage() {
@@ -53,13 +67,84 @@ export default function CardsPage() {
         onError: (error) => toast({ title: "Unable to remove card", description: error.message }),
     })
 
+    const [linkedAppliedFilter, setLinkedAppliedFilter] = useState<AppliedFilter>("all")
+    const [catalogAppliedFilter, setCatalogAppliedFilter] = useState<AppliedFilter>("all")
+    const [optimisticAppliedSlugs, setOptimisticAppliedSlugs] = useState<Set<string>>(new Set())
+    const [mandateSlugById, setMandateSlugById] = useState<Map<string, string>>(new Map())
+    const pendingMandateSlugs = useMemo(() => new Set(mandateSlugById.values()), [mandateSlugById])
+    const [pendingSlug, setPendingSlug] = useState<string | null>(null)
+
+    const filteredLinkedCards = useMemo(() => {
+        return cards.filter((card) => {
+            const slug = normalizeSlug((card as any).cardProductSlug ?? (card as any).productSlug)
+            const awaiting = slug ? pendingMandateSlugs.has(slug) : false
+            const optimistic = slug ? optimisticAppliedSlugs.has(slug) : false
+            const applied =
+                card.status === "Applied" ||
+                Boolean(card.appliedAt) ||
+                awaiting ||
+                optimistic
+            if (linkedAppliedFilter === "applied") return applied
+            if (linkedAppliedFilter === "not-applied") return !applied
+            return true
+        })
+    }, [cards, linkedAppliedFilter, optimisticAppliedSlugs, pendingMandateSlugs])
+
     useEffect(() => {
-        if (!cards.length) {
+        if (!filteredLinkedCards.length) {
             setSelectedId(undefined)
             return
         }
-        if (!selectedId || !cards.some((c) => c.id === selectedId)) setSelectedId(cards[0].id)
-    }, [cards, selectedId])
+        if (!selectedId || !filteredLinkedCards.some((c) => c.id === selectedId)) {
+            setSelectedId(filteredLinkedCards[0].id)
+        }
+    }, [filteredLinkedCards, selectedId])
+
+    useEffect(() => {
+        setOptimisticAppliedSlugs((prev) => {
+            if (!prev.size) return prev
+            const actualSlugs = new Set<string>()
+            for (const card of cards) {
+                const slug = normalizeSlug((card as any).cardProductSlug ?? (card as any).productSlug)
+                if (slug) actualSlugs.add(slug)
+            }
+            if (!actualSlugs.size) return prev
+            let changed = false
+            const next = new Set(prev)
+            for (const slug of prev) {
+                if (actualSlugs.has(slug)) {
+                    next.delete(slug)
+                    changed = true
+                }
+            }
+            return changed ? next : prev
+        })
+    }, [cards])
+
+    useEffect(() => {
+        const handleResolved = (event: Event) => {
+            const detail = (event as CustomEvent<FlowCoachMandateResolvedDetail>).detail
+            if (!detail?.id) return
+            let slug: string | undefined
+            setMandateSlugById((prev) => {
+                if (!prev.has(detail.id)) return prev
+                const next = new Map(prev)
+                slug = next.get(detail.id) ?? undefined
+                next.delete(detail.id)
+                return next
+            })
+            if (slug && detail.status === "declined") {
+                setOptimisticAppliedSlugs((prev) => {
+                    if (!prev.has(slug!)) return prev
+                    const next = new Set(prev)
+                    next.delete(slug!)
+                    return next
+                })
+            }
+        }
+        window.addEventListener(FLOW_COACH_MANDATE_RESOLVED_EVENT, handleResolved as EventListener)
+        return () => window.removeEventListener(FLOW_COACH_MANDATE_RESOLVED_EVENT, handleResolved as EventListener)
+    }, [])
 
     const [dialogOpen, setDialogOpen] = useState(false)
     const [editDialogOpen, setEditDialogOpen] = useState(false)
@@ -67,6 +152,14 @@ export default function CardsPage() {
 
     const summary = cardDetails.data?.summary
     const donutData = useMemo(() => summary?.byCategory ?? [], [summary])
+
+    const slugForEstimate = normalizeSlug(
+        (cardDetails.data as any)?.cardProductSlug ?? (cardDetails.data as any)?.productSlug,
+    )
+    const rewardsEstimate = useRewardsEstimate(
+        selectedId ? { cardId: selectedId, cardSlug: slugForEstimate ?? undefined } : undefined,
+        { enabled: Boolean(selectedId) },
+    )
 
     const handleDelete = (id: string) => deleteCard.mutate(id)
     const handleEdit = (id: string) => {
@@ -77,8 +170,14 @@ export default function CardsPage() {
         }
     }
 
+    const optimisticSlugList = useMemo(() => Array.from(optimisticAppliedSlugs), [optimisticAppliedSlugs])
+    const pendingSlugList = useMemo(() => Array.from(pendingMandateSlugs), [pendingMandateSlugs])
+
     // already-linked/applied matcher
-    const appliedMatcher = useMemo(() => buildAppliedMatcher(cards), [cards])
+    const appliedMatcher = useMemo(
+        () => buildAppliedMatcher(cards, [...optimisticSlugList, ...pendingSlugList]),
+        [cards, optimisticSlugList, pendingSlugList],
+    )
 
     /* =============== CATALOG =============== */
     const catalogQuery = useCardCatalog({ active: true })
@@ -101,46 +200,30 @@ export default function CardsPage() {
     const [categoryFilter, setCategoryFilter] = useState<string>("all")
     const [annualFeeFilter, setAnnualFeeFilter] = useState<AnnualFeeFilter>("all")
 
-    const [appliedSlugs, setAppliedSlugs] = useState<Set<string>>(new Set())
-    const [pendingSlug, setPendingSlug] = useState<string | null>(null)
-
-    const applyForCard = useApplyForCard({
-        onSuccess: (_data, variables) => {
-            const normalizedSlug = variables.slug.trim()
-            setAppliedSlugs((prev) => {
-                const next = new Set(prev)
-                next.add(normalizedSlug)
-                return next
-            })
-            toast({
-                title: "Application started",
-                description: `${variables.product_name} by ${variables.issuer}`,
-            })
-        },
-        onError: (error) => {
-            toast({
-                title: "Couldn’t start application",
-                description: error.message,
-            })
-        },
-        onSettled: () => setPendingSlug(null),
-    })
-
     const filteredCatalog = useMemo(() => {
         return catalogCards.filter((card) => {
             const matchesIssuer = issuerFilter === "all" || card.issuer === issuerFilter
             const matchesCategory =
                 categoryFilter === "all" || (card.rewards ?? []).some((r) => r.category === categoryFilter)
             const matchesFee = matchesAnnualFee(card.annual_fee, annualFeeFilter)
-            return matchesIssuer && matchesCategory && matchesFee
+            const slugValue = normalizeSlug(card.slug)
+            const applied = slugValue ? appliedMatcher(card) : false
+            const awaitingApproval = slugValue ? pendingMandateSlugs.has(slugValue) : false
+            const matchesAppliedState =
+                catalogAppliedFilter === "all"
+                    ? true
+                    : catalogAppliedFilter === "applied"
+                        ? applied || awaitingApproval
+                        : !(applied || awaitingApproval)
+            return matchesIssuer && matchesCategory && matchesFee && matchesAppliedState
         })
-    }, [catalogCards, issuerFilter, categoryFilter, annualFeeFilter])
+    }, [catalogCards, issuerFilter, categoryFilter, annualFeeFilter, catalogAppliedFilter, appliedMatcher, pendingMandateSlugs])
 
     // pagination
     const [page, setPage] = useState(1)
     useEffect(() => {
         setPage(1)
-    }, [issuerFilter, categoryFilter, annualFeeFilter, catalogCards.length])
+    }, [issuerFilter, categoryFilter, annualFeeFilter, catalogAppliedFilter, catalogCards.length])
 
     const totalPages = Math.max(1, Math.ceil(filteredCatalog.length / PAGE_SIZE))
     const start = (page - 1) * PAGE_SIZE
@@ -149,21 +232,74 @@ export default function CardsPage() {
 
     const [activeTab, setActiveTab] = useState<CardsTab>("linked")
 
-    const onApply = (product: CreditCardProduct) => {
+    const onApply = async (product: CreditCardProduct) => {
         if (!product.slug) {
             toast({ title: "Missing product slug", description: "Unable to start this application." })
             return
         }
-        if (applyForCard.isPending) {
+        const slugValue = normalizeSlug(product.slug)
+        if (!slugValue) {
+            toast({ title: "Missing product slug", description: "Unable to start this application." })
             return
         }
-        const slugValue = product.slug.trim()
+        if (pendingSlug && pendingSlug === slugValue) {
+            return
+        }
+        if (pendingMandateSlugs.has(slugValue) || optimisticAppliedSlugs.has(slugValue)) {
+            openFlowCoach()
+            return
+        }
+        if (appliedMatcher(product)) {
+            toast({ title: "Already applied", description: "This card already appears in your linked list." })
+            return
+        }
         setPendingSlug(slugValue)
-        applyForCard.mutate({
-            slug: slugValue,
-            product_name: product.product_name,
-            issuer: product.issuer,
-        })
+        try {
+            const mandate = await createMandate({
+                type: "intent",
+                data: {
+                    intent: "apply_card",
+                    product_slug: slugValue,
+                    product_name: product.product_name,
+                    issuer: product.issuer,
+                },
+            })
+            const attachment: MandateAttachment = {
+                ...mandate,
+                context: {
+                    productName: product.product_name,
+                    issuer: product.issuer,
+                    slug: slugValue,
+                },
+            }
+            setOptimisticAppliedSlugs((prev) => {
+                if (prev.has(slugValue)) return prev
+                const next = new Set(prev)
+                next.add(slugValue)
+                return next
+            })
+            setMandateSlugById((prev) => {
+                const next = new Map(prev)
+                next.set(attachment.id, slugValue)
+                return next
+            })
+            pushMandateToFlowCoach({
+                message: `Approve applying for the ${product.product_name}?`,
+                mandate: attachment,
+            })
+            openFlowCoach()
+            toast({
+                title: "Finish in Flow Coach",
+                description: "Approve the mandate to complete your application.",
+            })
+        } catch (error) {
+            toast({
+                title: "Couldn’t start application",
+                description: error instanceof Error ? error.message : "Please try again.",
+            })
+        } finally {
+            setPendingSlug(null)
+        }
     }
 
     return (
@@ -215,7 +351,7 @@ export default function CardsPage() {
                         <div className="flex flex-col gap-6 md:flex-row">
                             <div className="md:w-5/12 space-y-4">
                                 <CardSelector
-                                    cards={cards}
+                                    cards={filteredLinkedCards}
                                     selectedId={selectedId}
                                     onSelect={setSelectedId}
                                     onDelete={handleDelete}
@@ -223,6 +359,20 @@ export default function CardsPage() {
                                     onAdd={() => setDialogOpen(true)}
                                     isLoading={cardsQuery.isLoading}
                                     heightClass="max-h-[780px]"
+                                    headerActions={
+                                        <Select value={linkedAppliedFilter} onValueChange={(value) => setLinkedAppliedFilter(value as AppliedFilter)}>
+                                            <SelectTrigger className="h-8 w-[150px] text-xs">
+                                                <SelectValue placeholder="Filter" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {APPLIED_FILTERS.map((option) => (
+                                                    <SelectItem key={option.value} value={option.value}>
+                                                        {option.label}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    }
                                 />
                             </div>
 
@@ -237,7 +387,7 @@ export default function CardsPage() {
                                     <>
                                         <CreditCardDisplay card={cardDetails.data} />
 
-                                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                                             <StatTile label="30-day spend" value={currency2.format(summary?.spend ?? 0)} />
                                             <StatTile label="Transactions" value={(summary?.txns ?? 0).toLocaleString()} />
                                             <StatTile
@@ -246,6 +396,19 @@ export default function CardsPage() {
                                                 caption={
                                                     cardDetails.data.lastSynced
                                                         ? `Synced ${new Date(cardDetails.data.lastSynced).toLocaleDateString()}`
+                                                        : undefined
+                                                }
+                                            />
+                                            <StatTile
+                                                label={`${rewardsEstimate.data?.windowDays ?? 30}-day cash-back`}
+                                                value={
+                                                    rewardsEstimate.isLoading
+                                                        ? "…"
+                                                        : currency2.format(rewardsEstimate.data?.totalCashback ?? 0)
+                                                }
+                                                caption={
+                                                    rewardsEstimate.data
+                                                        ? `${percent1.format(rewardsEstimate.data.effectiveRate)} effective`
                                                         : undefined
                                                 }
                                             />
@@ -264,6 +427,38 @@ export default function CardsPage() {
                                                 />
                                             </CardContent>
                                         </Card>
+
+                                        {rewardsEstimate.data?.byCategory?.length ? (
+                                            <Card className="rounded-3xl">
+                                                <CardHeader>
+                                                    <CardTitle className="text-lg font-semibold">
+                                                        Cash-back highlights
+                                                    </CardTitle>
+                                                    <CardDescription>
+                                                        Last {rewardsEstimate.data.windowDays} days
+                                                    </CardDescription>
+                                                </CardHeader>
+                                                <CardContent className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                                    {rewardsEstimate.data.byCategory.slice(0, 4).map((entry) => (
+                                                        <Badge
+                                                            key={entry.category}
+                                                            variant="secondary"
+                                                            className="rounded-full px-3 py-1"
+                                                        >
+                                                            {entry.category}: {currency2.format(entry.cashback)} ({
+                                                                percent1.format(entry.rate)
+                                                            })
+                                                        </Badge>
+                                                    ))}
+                                                    {rewardsEstimate.data.byCategory.length > 4 ? (
+                                                        <span className="text-xs text-muted-foreground">
+                                                            +{rewardsEstimate.data.byCategory.length - 4} more categories earning
+                                                            rewards.
+                                                        </span>
+                                                    ) : null}
+                                                </CardContent>
+                                            </Card>
+                                        ) : null}
 
                                         {cardDetails.data.features?.length ? (
                                             <Card className="rounded-3xl">
@@ -313,6 +508,19 @@ export default function CardsPage() {
                         </CardHeader>
                         <CardContent className="space-y-4 p-6 md:p-8 pt-4">
                             <div className="grid gap-4 md:grid-cols-3">
+                                <Select value={catalogAppliedFilter} onValueChange={(value) => setCatalogAppliedFilter(value as AppliedFilter)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Applied status" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {APPLIED_FILTERS.map((option) => (
+                                            <SelectItem key={option.value} value={option.value}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+
                                 <Select value={issuerFilter} onValueChange={setIssuerFilter}>
                                     <SelectTrigger>
                                         <SelectValue placeholder="Filter by issuer" />
@@ -371,16 +579,19 @@ export default function CardsPage() {
                         </Card>
                     ) : (
                         <>
-                            <div className="grid gap-6 md:grid-cols-2">
+                            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
                                 {pageItems.map((product) => {
-                                    const applied = appliedSlugs.has(product.slug ?? "") || appliedMatcher(product)
+                                    const slugValue = normalizeSlug(product.slug)
+                                    const applied = appliedMatcher(product)
+                                    const awaitingApproval = slugValue ? pendingMandateSlugs.has(slugValue) : false
                                     return (
                                         <CatalogCreditCard
                                             key={product.slug ?? product.product_name}
                                             product={product}
                                             applied={applied}
+                                            awaitingApproval={awaitingApproval}
                                             onApply={() => onApply(product)}
-                                            isPending={pendingSlug === (product.slug ?? "").trim() && applyForCard.isPending}
+                                            isPending={pendingSlug === slugValue}
                                         />
                                     )
                                 })}
@@ -443,6 +654,12 @@ function formatAnnualFee(fee: number | null | undefined) {
     if (fee === 0) return "$0"
     return currency0.format(fee)
 }
+
+function normalizeSlug(value?: string | null): string | null {
+    if (typeof value !== "string") return null
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+}
 function extractCatalogCards(raw: any): CreditCardProduct[] {
     if (!raw) return []
     if (Array.isArray(raw)) return raw
@@ -467,7 +684,7 @@ function extractCatalogCards(raw: any): CreditCardProduct[] {
     return []
 }
 
-function buildAppliedMatcher(cards: CardRowType[]) {
+function buildAppliedMatcher(cards: CardRowType[], extraSlugs: Iterable<string> = []) {
     const norm = (s?: string | null) =>
         (s ?? "")
             .toLowerCase()
@@ -491,15 +708,21 @@ function buildAppliedMatcher(cards: CardRowType[]) {
         const joined = `${issuer} ${n1 || n2}`.trim()
         if (issuer && (n1 || n2)) issuerNameSet.add(joined)
 
-        const pslug = (c as any).productSlug
+        const pslug = normalizeSlug((c as any).cardProductSlug ?? (c as any).productSlug)
         if (pslug) slugSet.add(pslug)
+    }
+
+    for (const slug of extraSlugs) {
+        const normalized = normalizeSlug(slug)
+        if (normalized) slugSet.add(normalized)
     }
 
     return (p: CreditCardProduct) => {
         const pName = norm(p.product_name)
         const pIssuer = norm(p.issuer)
         const pJoined = `${pIssuer} ${pName}`.trim()
-        const slugMatch = p.slug ? slugSet.has(p.slug) : false
+        const normalizedSlug = normalizeSlug(p.slug)
+        const slugMatch = normalizedSlug ? slugSet.has(normalizedSlug) : false
         const nameMatch = pName ? nameSet.has(pName) : false
         const issuerMatch = pIssuer && pName ? issuerNameSet.has(pJoined) : false
         return slugMatch || nameMatch || issuerMatch
@@ -511,6 +734,7 @@ function buildAppliedMatcher(cards: CardRowType[]) {
 type CatalogCreditCardProps = {
     product: CreditCardProduct
     applied: boolean
+    awaitingApproval?: boolean
     onApply: () => void
     isPending?: boolean
 }
@@ -524,7 +748,7 @@ function gradientFor(product: CreditCardProduct) {
     return "from-violet-500 via-purple-500 to-fuchsia-600"
 }
 
-function CatalogCreditCard({ product, applied, onApply, isPending = false }: CatalogCreditCardProps) {
+function CatalogCreditCard({ product, applied, awaitingApproval = false, onApply, isPending = false }: CatalogCreditCardProps) {
     const gradient = gradientFor(product)
     const issuer = (product.issuer ?? "").toUpperCase()
     const name = product.product_name
@@ -541,6 +765,10 @@ function CatalogCreditCard({ product, applied, onApply, isPending = false }: Cat
                             {applied ? (
                                 <div className="rounded-full border border-white/40 bg-white/15 px-3 py-1 text-[11px] font-semibold">
                                     Applied
+                                </div>
+                            ) : awaitingApproval ? (
+                                <div className="rounded-full border border-white/40 bg-white/15 px-3 py-1 text-[11px] font-semibold">
+                                    Awaiting approval
                                 </div>
                             ) : null}
                         </div>
@@ -572,15 +800,9 @@ function CatalogCreditCard({ product, applied, onApply, isPending = false }: Cat
                     ))}
                 </div>
                 <div className="flex items-center gap-2">
-                    {applied ? (
-                        <Button variant="outline" size="sm" disabled>
-                            Applied
-                        </Button>
-                    ) : (
-                        <Button size="sm" onClick={onApply} disabled={isPending}>
-                            {isPending ? "Applying…" : "Apply"}
-                        </Button>
-                    )}
+                    <Button size="sm" onClick={onApply} disabled={applied || isPending}>
+                        {applied ? "Applied" : awaitingApproval ? "Open chat" : isPending ? "Applying…" : "Apply"}
+                    </Button>
                     {product.link_url ? (
                         <Button asChild variant="ghost" size="sm">
                             <a href={product.link_url} target="_blank" rel="noreferrer">
@@ -589,6 +811,9 @@ function CatalogCreditCard({ product, applied, onApply, isPending = false }: Cat
                         </Button>
                     ) : null}
                 </div>
+                {awaitingApproval && !applied ? (
+                    <p className="text-xs text-muted-foreground">Approve in Flow Coach to finish this application.</p>
+                ) : null}
             </div>
         </div>
     )

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
+import { MessageCircle } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -22,6 +23,7 @@ import {
 } from "@/hooks/useApi"
 import { useCardCatalog } from "@/hooks/useCards"
 import type { CardRow } from "@/types/api"
+import { openFlowCoach } from "@/lib/flow-coach"
 
 const currencyFormatter = new Intl.NumberFormat(undefined, {
     style: "currency",
@@ -160,6 +162,27 @@ export function HomePage() {
                         <StatTile label="Transactions" value={stats.txns.toLocaleString()} />
                         <StatTile label="Active cards" value={stats.accounts.toString()} />
                     </div>
+                </CardContent>
+            </Card>
+
+            {/* Flow Coach CTA */}
+            <Card className="rounded-3xl border border-primary/40 bg-primary/5">
+                <CardHeader className="p-6 md:p-8 pb-0">
+                    <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+                        <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+                            <MessageCircle className="h-4 w-4" />
+                        </span>
+                        Flow Coach
+                    </CardTitle>
+                    <CardDescription>Approve smart actions and get proactive nudges without leaving the dashboard.</CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-3 p-6 md:p-8 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-sm text-muted-foreground">
+                        Gemini tracks spend trends, drafts budgets, and surfaces subscriptions. Tap below to open the chat.
+                    </p>
+                    <Button size="sm" onClick={() => openFlowCoach()}>
+                        Chat with Flow Coach
+                    </Button>
                 </CardContent>
             </Card>
 

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -65,8 +65,14 @@ export type CardRow = {
   mask: string
   type: "credit_card"
   expires?: string | null
-  status: "Active" | "Needs Attention"
+  status: "Active" | "Needs Attention" | "Applied"
   lastSynced?: string | null
+  appliedAt?: string | null
+  cardProductId?: string | null
+  cardProductSlug?: string | null
+  productName?: string | null
+  account_mask?: string | null
+  credit_limit?: number | null
 }
 
 export type CardSummary = {
@@ -80,6 +86,27 @@ export type CardDetails = CardRow & {
   productName?: string
   features?: string[]
   summary?: CardSummary
+}
+
+export type RewardsEstimateCategory = {
+  category: string
+  spend: number
+  rate: number
+  cashback: number
+  transactions: number
+  capMonthly?: number | null
+}
+
+export type RewardsEstimate = {
+  cardId?: string
+  cardSlug?: string | null
+  cardName?: string | null
+  windowDays: number
+  totalCashback: number
+  totalSpend: number
+  effectiveRate: number
+  baseRate: number
+  byCategory: RewardsEstimateCategory[]
 }
 
 export type CreditCardReward = {
@@ -162,11 +189,27 @@ export type RecommendationResponse = {
   explanation: string
 }
 
+export type MandateStatus = "pending_approval" | "approved" | "declined" | "executed"
+
+export type Mandate = {
+  id: string
+  type: "intent" | "cart" | "payment"
+  status: MandateStatus
+  data: Record<string, unknown>
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+export type MandateAttachment = Mandate & {
+  context?: Record<string, unknown>
+}
+
 export type ChatMessage = {
   id: string
   author: "user" | "assistant"
   content: string
   timestamp: string
+  mandate?: MandateAttachment
 }
 
 export type ChatResponse = {

--- a/server/services/rewards.py
+++ b/server/services/rewards.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+def _normalize_rewards(rewards: Iterable[Dict[str, Any]] | None) -> List[Dict[str, Any]]:
+    formatted: List[Dict[str, Any]] = []
+    for reward in rewards or []:
+        category_raw = reward.get("category")
+        rate_raw = reward.get("rate")
+        if not category_raw or rate_raw is None:
+            continue
+        try:
+            rate = float(rate_raw)
+        except (TypeError, ValueError):
+            continue
+        category = str(category_raw).strip()
+        if not category:
+            continue
+        entry: Dict[str, Any] = {
+            "category": category,
+            "key": category.lower(),
+            "rate": rate,
+        }
+        cap_value = reward.get("cap_monthly")
+        if cap_value is not None:
+            try:
+                entry["cap_monthly"] = float(cap_value)
+            except (TypeError, ValueError):
+                pass
+        formatted.append(entry)
+    return formatted
+
+
+def summarize_spend(transactions: Iterable[Dict[str, Any]]) -> Tuple[float, Dict[str, float], Dict[str, int]]:
+    totals: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    total_spend = 0.0
+    for txn in transactions:
+        amount_raw = txn.get("amount", 0)
+        try:
+            amount = float(amount_raw or 0)
+        except (TypeError, ValueError):
+            amount = 0.0
+        amount = max(amount, 0.0)
+        if amount <= 0:
+            continue
+        category = str(txn.get("category") or "General")
+        totals[category] = totals.get(category, 0.0) + amount
+        counts[category] = counts.get(category, 0) + 1
+        total_spend += amount
+    return total_spend, totals, counts
+
+
+def compute_month_earnings(card: Dict[str, Any], transactions: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    base_rate = float(card.get("base_cashback") or 0.0)
+    rewards = _normalize_rewards(card.get("rewards"))
+
+    total_spend, totals_by_category, counts = summarize_spend(transactions)
+    total_cashback = 0.0
+    breakdown: List[Dict[str, Any]] = []
+
+    for category, spend in sorted(totals_by_category.items(), key=lambda item: item[1], reverse=True):
+        lookup_key = category.lower()
+        reward = next((row for row in rewards if row["key"] == lookup_key), None)
+        rate = reward["rate"] if reward else base_rate
+        cap = reward.get("cap_monthly") if reward else None
+
+        eligible = spend
+        if isinstance(cap, (int, float)):
+            eligible = min(spend, float(cap))
+
+        base_cash = base_rate * spend
+        bonus_cash = max(rate - base_rate, 0.0) * eligible
+        cashback = base_cash + bonus_cash
+        total_cashback += cashback
+
+        breakdown.append(
+            {
+                "category": category,
+                "spend": round(spend, 2),
+                "rate": round(rate, 4),
+                "cashback": round(cashback, 2),
+                "transactions": counts.get(category, 0),
+                "capMonthly": float(cap) if isinstance(cap, (int, float)) else None,
+            }
+        )
+
+    effective_rate = (total_cashback / total_spend) if total_spend else 0.0
+
+    return {
+        "total_cashback": round(total_cashback, 2),
+        "total_spend": round(total_spend, 2),
+        "effective_rate": round(effective_rate, 4),
+        "base_rate": round(base_rate, 4),
+        "by_category": breakdown,
+    }
+
+
+def normalize_mix(raw_mix: Dict[str, Any]) -> Tuple[Dict[str, float], float]:
+    sanitized: Dict[str, float] = {}
+    for key, value in raw_mix.items():
+        try:
+            amount = float(value)
+        except (TypeError, ValueError):
+            continue
+        if amount <= 0:
+            continue
+        sanitized[str(key)] = amount
+
+    total = sum(sanitized.values())
+    if total <= 0:
+        return {}, 0.0
+
+    mix = {category: amount / total for category, amount in sanitized.items()}
+    return mix, total


### PR DESCRIPTION
## Summary
- add AP2 mandate CRUD routes, execution logic for card applications, rewards estimation/compare endpoints, and supporting indexes/services on the server
- introduce mandate utilities, MandateCard UI, and Flow Coach event wiring so catalog applications run through AP2 and cards list tracks pending approvals and cashback
- surface Flow Coach on the homepage and extend cards filters/pagination to highlight applied status with reward estimates in the linked-card details view

## Testing
- `npm run build` *(fails: existing TypeScript issues in AddCardDialog.tsx lines 62/82 and BestCardFinder.tsx lines 11/71)*

------
https://chatgpt.com/codex/tasks/task_e_68cf31d1e93c8326bfb8edf5a3260807