### PR TITLE
Add cashback scenarios to cards page

### DIFF
--- a/client/src/components/cards/CreditCardDisplay.tsx
+++ b/client/src/components/cards/CreditCardDisplay.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge"
+import { gradientForIssuer } from "@/utils/brand-gradient"
 import { cn } from "@/lib/utils"
 import type { CardRow } from "@/types/api"
 
@@ -7,25 +8,39 @@ type CreditCardDisplayProps = {
   holderName?: string | null
 }
 
-const GRADIENTS = [
-  "from-indigo-500 via-indigo-400 to-violet-500",
-  "from-violet-500 via-fuchsia-500 to-indigo-500",
-  "from-emerald-500 via-teal-400 to-cyan-400",
-  "from-blue-500 via-sky-400 to-cyan-400",
-]
+function normalizeSlug(value?: string | null) {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
 
 export function CreditCardDisplay({ card, holderName }: CreditCardDisplayProps) {
   const needsAttention = card.status === "Needs Attention"
-  const gradient = GRADIENTS[card.nickname.charCodeAt(0) % GRADIENTS.length]
+  const issuer = (card.issuer ?? "").toUpperCase()
+  const nickname = card.nickname || (card as any).productName || "Your Card"
+  const gradient = gradientForIssuer(
+    (card as any)?.cardProductId,
+    (card as any)?.cardProductSlug,
+    (card as any)?.productSlug,
+    (card as any)?.productName,
+    card.issuer,
+    card.network,
+    nickname
+  )
   const expiryMonth = card.expires ? card.expires.split("-")[1] : undefined
   const expiryYear = card.expires ? card.expires.slice(2, 4) : undefined
+  const slug =
+    normalizeSlug((card as any)?.cardProductSlug) ||
+    normalizeSlug((card as any)?.productSlug) ||
+    normalizeSlug((card as any)?.cardProductId) ||
+    "—"
 
   return (
     <div className={cn("relative overflow-hidden rounded-3xl bg-gradient-to-br p-6 text-white shadow-card", gradient)}>
       <div className="flex items-center justify-between">
         <div className="space-y-1">
-          <p className="text-xs uppercase tracking-[0.3em] text-white/80">{card.issuer}</p>
-          <h3 className="text-2xl font-semibold">{card.nickname}</h3>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/80">{issuer || "CARD ISSUER"}</p>
+          <h3 className="text-2xl font-semibold leading-7">{nickname}</h3>
         </div>
         <Badge
           variant={needsAttention ? "outline" : "success"}
@@ -38,10 +53,17 @@ export function CreditCardDisplay({ card, holderName }: CreditCardDisplayProps) 
         </Badge>
       </div>
       <div className="mt-10 space-y-3 text-sm">
-        <p className="text-white/70">•••• •••• •••• {card.mask}</p>
+        <p className="text-white/70">•••• •••• •••• {card.mask || "0000"}</p>
         <div className="flex items-center justify-between text-xs uppercase tracking-wide text-white/80">
           <span>{holderName || "Swipe Coach member"}</span>
           {expiryMonth && expiryYear ? <span>Exp {expiryMonth}/{expiryYear}</span> : null}
+        </div>
+      </div>
+      <div className="mt-6 flex items-end justify-between text-xs text-white/85">
+        <span className="tracking-[0.2em] text-white/60">CARD PRODUCT</span>
+        <div className="text-right">
+          <div className="uppercase tracking-wide text-white/70">Slug</div>
+          <div className="text-base font-semibold leading-5 text-white">{slug}</div>
         </div>
       </div>
       <div className="absolute -right-12 -top-12 h-40 w-40 rounded-full bg-white/10 blur-3xl" />

--- a/client/src/components/ui/BestCardFinder.tsx
+++ b/client/src/components/ui/BestCardFinder.tsx
@@ -249,7 +249,12 @@ export function BestCardFinder({
             categories: Array.isArray(a.categories) ? a.categories : undefined,
             cap: a.cap || undefined,
           }))
-          .sort((A, B) => (B.percentBack ?? 0) - (A.percentBack ?? 0)),
+          .sort(
+            (
+              A: { percentBack?: number | null },
+              B: { percentBack?: number | null }
+            ) => (B.percentBack ?? 0) - (A.percentBack ?? 0)
+          ),
         matchConfidence: data.matchConfidence,
         categorySource: data.categorySource,
       };

--- a/client/src/pages/CardsPage.tsx
+++ b/client/src/pages/CardsPage.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 
-import { DonutChart } from "@/components/charts/DonutChart"
 import { StatTile } from "@/components/cards/StatTile"
 import { CardSelector } from "@/components/cards/CardSelector"
 import { CreditCardDisplay } from "@/components/cards/CreditCardDisplay"
@@ -150,9 +149,7 @@ export default function CardsPage() {
     const [dialogOpen, setDialogOpen] = useState(false)
     const [editDialogOpen, setEditDialogOpen] = useState(false)
     const [editingCard, setEditingCard] = useState<CardRowType | null>(null)
-
-    const summary = cardDetails.data?.summary
-    const donutData = useMemo(() => summary?.byCategory ?? [], [summary])
+    const [selectedScenarioId, setSelectedScenarioId] = useState<string | null>(null)
 
     const slugForEstimate = normalizeSlug(
         (cardDetails.data as any)?.cardProductSlug ?? (cardDetails.data as any)?.productSlug,
@@ -161,6 +158,34 @@ export default function CardsPage() {
         selectedId ? { cardId: selectedId, cardSlug: slugForEstimate ?? undefined } : undefined,
         { enabled: Boolean(selectedId) },
     )
+
+    const scenarioCount = cardDetails.data?.cashbackScenarios?.length ?? 0
+    useEffect(() => {
+        const scenarios = cardDetails.data?.cashbackScenarios ?? []
+        if (!scenarios.length) {
+            setSelectedScenarioId(null)
+            return
+        }
+        setSelectedScenarioId((current) => {
+            if (current && scenarios.some((scenario) => scenario.id === current)) {
+                return current
+            }
+            return scenarios[0].id
+        })
+    }, [cardDetails.data?.id, scenarioCount])
+
+    const scenarioList = cardDetails.data?.cashbackScenarios ?? []
+    const selectedScenario =
+        scenarioList.find((scenario) => scenario.id === selectedScenarioId) ??
+        (scenarioList.length ? scenarioList[0] : null)
+
+    const effectiveLabel = rewardsEstimate.data
+        ? `${percent1.format(rewardsEstimate.data.effectiveRate)} effective`
+        : undefined
+    const lastSyncedLabel = cardDetails.data?.lastSynced
+        ? `Synced ${new Date(cardDetails.data.lastSynced).toLocaleDateString()}`
+        : undefined
+    const cashbackCaption = [effectiveLabel, lastSyncedLabel].filter(Boolean).join(" • ") || undefined
 
     const handleDelete = (id: string) => deleteCard.mutate(id)
     const handleEdit = (id: string) => {
@@ -389,16 +414,34 @@ export default function CardsPage() {
                                         <CreditCardDisplay card={cardDetails.data} />
 
                                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                                            <StatTile label="30-day spend" value={currency2.format(summary?.spend ?? 0)} />
-                                            <StatTile label="Transactions" value={(summary?.txns ?? 0).toLocaleString()} />
                                             <StatTile
-                                                label="Status"
-                                                value={cardDetails.data.status}
-                                                caption={
-                                                    cardDetails.data.lastSynced
-                                                        ? `Synced ${new Date(cardDetails.data.lastSynced).toLocaleDateString()}`
-                                                        : undefined
+                                                label="Estimated cash-back"
+                                                value={
+                                                    selectedScenario
+                                                        ? currency2.format(selectedScenario.estimatedCashback)
+                                                        : currency2.format(0)
                                                 }
+                                                caption={
+                                                    selectedScenario
+                                                        ? `Scenario: ${selectedScenario.label}`
+                                                        : "Pick a scenario to preview rewards"
+                                                }
+                                            />
+                                            <StatTile
+                                                label="Scenario spend"
+                                                value={
+                                                    selectedScenario
+                                                        ? currency2.format(selectedScenario.amount)
+                                                        : currency2.format(0)
+                                                }
+                                                caption={
+                                                    selectedScenario ? `Category: ${selectedScenario.category}` : undefined
+                                                }
+                                            />
+                                            <StatTile
+                                                label="Base cash-back rate"
+                                                value={percent1.format(rewardsEstimate.data?.baseRate ?? 0)}
+                                                caption="Applies when no bonus category matches"
                                             />
                                             <StatTile
                                                 label={`${rewardsEstimate.data?.windowDays ?? 30}-day cash-back`}
@@ -407,25 +450,87 @@ export default function CardsPage() {
                                                         ? "…"
                                                         : currency2.format(rewardsEstimate.data?.totalCashback ?? 0)
                                                 }
-                                                caption={
-                                                    rewardsEstimate.data
-                                                        ? `${percent1.format(rewardsEstimate.data.effectiveRate)} effective`
-                                                        : undefined
-                                                }
+                                                caption={cashbackCaption}
                                             />
                                         </div>
 
                                         <Card className="rounded-3xl">
                                             <CardHeader>
-                                                <CardTitle className="text-lg font-semibold">Category breakdown</CardTitle>
-                                                <CardDescription>Last 30 days</CardDescription>
+                                                <CardTitle className="text-lg font-semibold">Cash-back scenario planner</CardTitle>
+                                                <CardDescription>
+                                                    Explore how this card rewards common purchases.
+                                                </CardDescription>
                                             </CardHeader>
-                                            <CardContent className="h-64 p-0">
-                                                <DonutChart
-                                                    data={donutData}
-                                                    isLoading={cardDetails.isLoading}
-                                                    emptyMessage="No spending yet in the last 30 days."
-                                                />
+                                            <CardContent className="space-y-4">
+                                                {scenarioList.length ? (
+                                                    <>
+                                                        <div className="overflow-x-auto overscroll-contain scroll-smooth rounded-2xl scrollbar-thin scrollbar-thumb-muted-foreground/30 hover:scrollbar-thumb-muted-foreground/50 scrollbar-track-transparent scrollbar-corner-transparent">
+                                                            <div className="flex min-w-full gap-3 p-1">
+                                                                {scenarioList.map((scenario) => {
+                                                                    const isActive = selectedScenario?.id === scenario.id
+                                                                    return (
+                                                                        <button
+                                                                            key={scenario.id}
+                                                                            type="button"
+                                                                            aria-pressed={isActive}
+                                                                            onClick={() => setSelectedScenarioId(scenario.id)}
+                                                                            className={[
+                                                                                "group flex min-w-[220px] flex-col gap-3 rounded-2xl border p-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2",
+                                                                                isActive
+                                                                                    ? "border-primary bg-primary/10 shadow-[0_18px_45px_-30px_rgba(59,130,246,0.9)]"
+                                                                                    : "border-border/60 bg-background/60 hover:border-primary/40",
+                                                                            ].join(" ")}
+                                                                        >
+                                                                            <div className="flex items-center justify-between gap-2">
+                                                                                <span className="text-sm font-semibold leading-tight">
+                                                                                    {scenario.label}
+                                                                                </span>
+                                                                                <Badge
+                                                                                    variant={isActive ? "default" : "secondary"}
+                                                                                    className="rounded-full px-3 py-1 text-[11px] font-medium"
+                                                                                >
+                                                                                    {scenario.category}
+                                                                                </Badge>
+                                                                            </div>
+                                                                            <p className="text-xs text-muted-foreground line-clamp-2">
+                                                                                {scenario.description ??
+                                                                                    `Spend ${currency2.format(scenario.amount)} on ${scenario.category}.`}
+                                                                            </p>
+                                                                            <div className="mt-auto flex items-end justify-between gap-3">
+                                                                                <div>
+                                                                                    <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                                                                                        Spend
+                                                                                    </div>
+                                                                                    <div className="text-lg font-semibold">
+                                                                                        {currency2.format(scenario.amount)}
+                                                                                    </div>
+                                                                                </div>
+                                                                                <div className="text-right">
+                                                                                    <div className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                                                                                        Cash-back
+                                                                                    </div>
+                                                                                    <div className="text-lg font-semibold">
+                                                                                        {currency2.format(scenario.estimatedCashback)}
+                                                                                    </div>
+                                                                                    <div className="text-[11px] text-muted-foreground">
+                                                                                        @ {percent1.format(scenario.rate)}
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </button>
+                                                                    )
+                                                                })}
+                                                            </div>
+                                                        </div>
+                                                        {selectedScenario?.description ? (
+                                                            <p className="text-sm text-muted-foreground">{selectedScenario.description}</p>
+                                                        ) : null}
+                                                    </>
+                                                ) : (
+                                                    <p className="text-sm text-muted-foreground">
+                                                        No example purchases yet. Check back soon.
+                                                    </p>
+                                                )}
                                             </CardContent>
                                         </Card>
 

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -82,10 +82,21 @@ export type CardSummary = {
   byCategory: { name: string; total: number }[]
 }
 
+export type CardCashbackScenario = {
+  id: string
+  label: string
+  category: string
+  amount: number
+  estimatedCashback: number
+  rate: number
+  description?: string | null
+}
+
 export type CardDetails = CardRow & {
   productName?: string
   features?: string[]
   summary?: CardSummary
+  cashbackScenarios?: CardCashbackScenario[]
 }
 
 export type RewardsEstimateCategory = {


### PR DESCRIPTION
## Summary
- seed default cashback scenarios in MongoDB and surface them from the card details endpoint
- refresh the cards page to focus on cashback stats and include a Tailwind-styled scenario planner carousel
- align the credit card display styling/slug presentation with the homepage and tighten TypeScript types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf5b923c3c8326aa834b11f38577bc